### PR TITLE
feat/issue-81/UserPage->StudentId,Admin,Student,TutorRoleapply

### DIFF
--- a/src/main/java/com/project/handongjudge/user/controller/UserController.java
+++ b/src/main/java/com/project/handongjudge/user/controller/UserController.java
@@ -68,6 +68,10 @@ public class UserController {
      */
     @GetMapping("/dashboard")
     public ResponseEntity<Map<String, Object>> getDashboardCourses(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication.getPrincipal() == null || "anonymousUser".equals(authentication.getName())) {
+            return buildErrorResponse("로그인이 필요합니다.");
+        }
         try {
             Long userId = Long.parseLong(authentication.getName());
             List<DashboardCourseDto> courses = userService.getDashboardCourses(userId);
@@ -79,7 +83,8 @@ public class UserController {
             return ResponseEntity.ok(response);
 
         } catch (Exception e) {
-            log.error("대시보드 조회 실패: {}", authentication.getName(), e);
+            String name = authentication != null ? authentication.getName() : "null";
+            log.error("대시보드 조회 실패: {}", name, e);
             return buildErrorResponse("대시보드 정보를 가져오지 못했습니다.");
         }
     }

--- a/src/main/java/com/project/handongjudge/user/dto/StudentDto.java
+++ b/src/main/java/com/project/handongjudge/user/dto/StudentDto.java
@@ -28,4 +28,7 @@ public class StudentDto {
     private Double assignmentCompletionRate;  // 전체 과제 완료율 (%)
     private Integer completedAssignments;      // 완료한 과제 수
     private Integer totalAssignments;          // 전체 과제 수
+
+    /** 분반 내 역할 (ADMIN, TUTOR, STUDENT) - 서비스 레이어에서 설정 */
+    private String role;
 }

--- a/src/main/java/com/project/handongjudge/user/repository/EnrollmentRepository.java
+++ b/src/main/java/com/project/handongjudge/user/repository/EnrollmentRepository.java
@@ -29,10 +29,10 @@ public interface EnrollmentRepository extends CrudRepository<Enrollment, Long> {
 
 
     @Query("SELECT new com.project.handongjudge.user.dto.StudentDto(" +
-            "u.id, u.name, u.email, '', e.teamId, s.id, " +
+            "u.id, u.name, u.email, COALESCE(u.studentId, ''), e.teamId, s.id, " +
             "CONCAT(c.title, ' - Section ', s.sectionNumber), c.title, s.sectionNumber, " +
             "e.joinedAt, u.updatedAt, " +
-            "0.0, 0, 0) " +
+            "0.0, 0, 0, '') " +
             "FROM Enrollment e " +
             "JOIN e.user u " +
             "JOIN e.section s " +
@@ -44,7 +44,7 @@ public interface EnrollmentRepository extends CrudRepository<Enrollment, Long> {
             "u.id, u.name, u.email, '', e.teamId, s.id, " +
             "CONCAT(c.title, ' - Section ', s.sectionNumber), c.title, s.sectionNumber, " +
             "e.joinedAt, u.updatedAt, " +
-            "0.0, 0, 0) " +
+            "0.0, 0, 0, '') " +
             "FROM Enrollment e " +
             "JOIN e.user u " +
             "JOIN e.section s " +

--- a/src/main/java/com/project/handongjudge/user/service/UserService.java
+++ b/src/main/java/com/project/handongjudge/user/service/UserService.java
@@ -251,6 +251,14 @@ public class UserService {
             calculateAssignmentProgress(student, sectionId);
         }
 
+        // 분반 내 역할 설정 (ADMIN, TUTOR, STUDENT)
+        for (StudentDto student : students) {
+            String roleName = sectionRoleService.getUserRoleInSection(student.getUserId(), sectionId)
+                    .map(Enum::name)
+                    .orElse("STUDENT");
+            student.setRole(roleName);
+        }
+
         return students;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #81 

### 수정 요약
- 분반별 학생 조회 시 학번·역할 반환, 대시보드 미인증 접근 방지

### 변경 파일 및 내용

| 파일 | 변경 내용 |
|------|-----------|
| `StudentDto.java` | **추가:** `private String role;` (분반 내 역할: ADMIN, TUTOR, STUDENT). 서비스 레이어에서 설정. |
| `EnrollmentRepository.java` | **findStudentsBySectionId:** 4번째 인자 `''` → `COALESCE(u.studentId, '')` (학번 반환), 생성자 마지막에 `role` 인자 추가 → `0.0, 0, 0, '')` · **findStudentsByInstructorId:** 생성자 마지막에 `role` 인자 추가 → `0.0, 0, 0, '')` |
| `UserService.java` | **getStudentsBySection:** `findStudentsBySectionId` + 진도율 계산 후, 각 `StudentDto`에 대해 `sectionRoleService.getUserRoleInSection(userId, sectionId)`로 역할 조회 후 `student.setRole(roleName)` 설정 (없으면 `"STUDENT"`) |
| `UserController.java` | **getDashboardCourses:** `authentication == null` / 미인증 / `anonymousUser`인 경우 즉시 "로그인이 필요합니다." 응답 · catch 블록에서 `authentication.getName()` null 방지 처리 |

### 동작 변경 요약
- **학번:** 분반별 학생 조회 시 `User.studentId`를 `COALESCE(u.studentId, '')`로 DTO에 넣어 응답
- **역할:** 분반별 학생 목록 API 응답에 각 수강생의 분반 내 역할(`role`) 포함 → 프론트에서 튜터 추가 후 재조회 시 역할이 바로 반영됨
- **대시보드:** 비로그인/만료된 JWT 등으로 인한 NPE 방지를 위해 미인증 시 조기 리턴 및 로깅 시 null-safe 처리

---

## 연동 정리
- FE는 분반 학생 목록 API 응답의 `studentId`, `role`을 사용해 학번 컬럼 표시 및 튜터 추가/제거 버튼 노출을 제어함.
- BE는 `StudentDto`에 `role`을 채워 주고, JPQL 생성자에는 초기값 `''`를 넘기며 서비스에서 `SectionRoleService`로 실제 역할을 설정함.
