### PR TITLE
수강생 과제 조회 권한: Enrollment 기준 허용

### DIFF
--- a/src/main/java/com/project/handongjudge/assignment/service/AssignmentService.java
+++ b/src/main/java/com/project/handongjudge/assignment/service/AssignmentService.java
@@ -118,11 +118,12 @@ public class AssignmentService {
         Section section = sectionRepository.findById(sectionId)
                 .orElseThrow(() -> new IllegalArgumentException("Section not found"));
 
-        // 권한 확인: 관리자이거나 수강생이어야 함
+        // 권한 확인: 관리자이거나 수강생이어야 함 (SectionUserRole 또는 Enrollment 기준)
         boolean isManager = sectionRoleService.isManager(userId, sectionId);
         boolean isStudent = sectionRoleService.isStudent(userId, sectionId);
+        boolean isEnrolled = enrollmentRepository.existsByUserIdAndSectionId(userId, sectionId);
 
-        if (!isManager && !isStudent) {
+        if (!isManager && !isStudent && !isEnrolled) {
             throw new IllegalArgumentException("해당 분반의 과제를 조회할 권한이 없습니다");
         }
 
@@ -131,7 +132,7 @@ public class AssignmentService {
             // 관리자는 모든 과제 조회 (active 여부와 관계없이)
             assignments = assignmentRepository.findAllAssignmentsBySectionId(sectionId);
         } else {
-            // 학생은 active=true인 과제만 조회
+            // 수강생(학생 또는 Enrollment만 있는 경우)은 active=true인 과제만 조회
             assignments = assignmentRepository.findActiveAssignmentsBySectionId(sectionId);
         }
 
@@ -186,11 +187,12 @@ public class AssignmentService {
         // Section 조회
         Section section = assignment.getSection();
 
-        // 권한 확인: 관리자이거나 수강생이어야 함
+        // 권한 확인: 관리자이거나 수강생이어야 함 (SectionUserRole 또는 Enrollment 기준)
         boolean isManager = sectionRoleService.isManager(userId, section.getId());
         boolean isStudent = sectionRoleService.isStudent(userId, section.getId());
+        boolean isEnrolled = enrollmentRepository.existsByUserIdAndSectionId(userId, section.getId());
 
-        if (!isManager && !isStudent) {
+        if (!isManager && !isStudent && !isEnrolled) {
             throw new IllegalArgumentException("해당 과제를 조회할 권한이 없습니다");
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#84 

## Backend (Handongjudge_BE)

### [BE] 수강생 과제 조회 권한: Enrollment 기준 허용

**제목:** 해당 분반 과제 조회 시 Enrollment만 있는 수강생도 접근 허용

**설명:**  
대시보드는 Enrollment 기준으로 수강 중인 수업을 보여주는데, 과제 API는 SectionUserRole(MANAGER/STUDENT)만 허용하여, Enrollment만 있고 SectionUserRole에 STUDENT가 없는 경우 400 "해당 분반의 과제를 조회할 권한이 없습니다"가 발생함.

**수정 파일:**  
- `Handongjudge_BE/src/main/java/com/project/handongjudge/assignment/service/AssignmentService.java`

**수정 내용:**
- `getAssignmentsBySection(sectionId, userId)`  
  - `enrollmentRepository.existsByUserIdAndSectionId(userId, sectionId)`로 수강 여부 추가 확인  
  - 허용 조건: `isManager || isStudent` → `isManager || isStudent || isEnrolled`  
  - 관리자가 아니면 기존과 동일하게 `findActiveAssignmentsBySectionId(sectionId)`만 반환
- `getAssignmentInfo(assignmentId, userId)`  
  - 동일하게 `isEnrolled` 조건 추가  
  - `isManager || isStudent || isEnrolled`일 때 해당 과제 조회 허용

**체크리스트:**
- [x] Enrollment만 있는 사용자로 `GET /api/sections/{sectionId}/assignments` 호출 시 200 및 목록 반환
- [ ] Enrollment만 있는 사용자로 과제 단건 조회 시 200 및 단건 반환
- [ ] 해당 분반에 Enrollment도 SectionUserRole도 없는 사용자는 400 유지