### PR TITLE
1. 과제 삭제시 문제있는 과제의 FK제약 처리

### DIFF
--- a/src/main/java/com/project/handongjudge/assignment/service/AssignmentService.java
+++ b/src/main/java/com/project/handongjudge/assignment/service/AssignmentService.java
@@ -5,6 +5,8 @@ import com.project.handongjudge.assignment.entity.Assignment;
 import com.project.handongjudge.assignment.entity.AssignmentProblem;
 import com.project.handongjudge.assignment.repository.AssignmentRepository;
 import com.project.handongjudge.assignment.repository.AssignmentProblemRepository;
+import com.project.handongjudge.community.repository.NotificationRepository;
+import com.project.handongjudge.community.repository.QuestionRepository;
 import com.project.handongjudge.community.service.NotificationService;
 import com.project.handongjudge.problem.entity.Problem;
 import com.project.handongjudge.problem.repository.ProblemRepository;
@@ -42,6 +44,8 @@ public class AssignmentService {
     private final SubmissionRepository submissionRepository;
     private final EnrollmentRepository enrollmentRepository;
     private final NotificationService notificationService;
+    private final NotificationRepository notificationRepository;
+    private final QuestionRepository questionRepository;
     private final UserRepository userRepository;
 
     public AssignmentResponse createAssignment(Long sectionId, AssignmentRequest request, Long userId) {
@@ -471,6 +475,12 @@ public class AssignmentService {
         if (!sectionRoleService.isManager(userId, assignment.getSection().getId())) {
             throw new IllegalArgumentException("과제 삭제는 수업 관리자(교수/조교)만 가능합니다");
         }
+
+        // notifications.assignment_id FK 제약 회피: 이 과제를 참조하는 알림 먼저 삭제
+        notificationRepository.deleteByAssignment_IdIn(Collections.singletonList(assignmentId));
+
+        // questions.assignment_id FK 제약 회피: 해당 과제를 참조하는 질문의 연관만 해제 (질문은 수업에 남김)
+        questionRepository.setAssignmentNullByAssignmentId(assignmentId);
 
         // 과제에 연결된 문제 관계 삭제
         assignmentProblemRepository.deleteByAssignmentId(assignmentId);

--- a/src/main/java/com/project/handongjudge/community/repository/QuestionRepository.java
+++ b/src/main/java/com/project/handongjudge/community/repository/QuestionRepository.java
@@ -6,6 +6,7 @@ import com.project.handongjudge.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -59,6 +60,11 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     // 핀된 질문 목록
     List<Question> findBySectionAndIsPinnedTrueOrderByCreatedAtDesc(Section section);
+
+    /** 과제 삭제 시 FK 제약 회피: 해당 과제를 참조하는 질문의 assignment를 null로 변경 (질문은 유지) */
+    @Modifying
+    @Query("UPDATE Question q SET q.assignment = null WHERE q.assignment.id = :assignmentId")
+    int setAssignmentNullByAssignmentId(@Param("assignmentId") Long assignmentId);
 }
 
 

--- a/src/main/java/com/project/handongjudge/notice/dto/NoticeResponseDto.java
+++ b/src/main/java/com/project/handongjudge/notice/dto/NoticeResponseDto.java
@@ -12,6 +12,7 @@ public class NoticeResponseDto {
     private Long id;
     private Long sectionId;
     private String sectionName; // 분반 정보 (예: "컴퓨터과학개론 - 16분반")
+    private String instructorName; // 작성자(해당 수업 담당 교수)
     private String title;
     private String content;
     private String difficulty;

--- a/src/main/java/com/project/handongjudge/notice/service/NoticeService.java
+++ b/src/main/java/com/project/handongjudge/notice/service/NoticeService.java
@@ -137,11 +137,13 @@ public class NoticeService {
         // 분반 정보 생성 (예: "컴퓨터과학개론 - 16분반")
         Section section = notice.getSection();
         String sectionName = section.getCourse().getTitle() + " - " + section.getSectionNumber() + "분반";
-        
+        String instructorName = section.getInstructor() != null ? section.getInstructor().getName() : null;
+
         return NoticeResponseDto.builder()
                 .id(notice.getId())
                 .sectionId(notice.getSection().getId())
                 .sectionName(sectionName)
+                .instructorName(instructorName)
                 .title(notice.getTitle())
                 .content(notice.getContent())
                 .difficulty(notice.getDifficulty())


### PR DESCRIPTION
## Backend (Handongjudge_BE)

### 1. 과제 삭제 시 FK 제약 처리
- **파일:** `assignment/service/AssignmentService.java`
  - `NotificationRepository` 주입 후, 과제 삭제 전에 해당 과제를 참조하는 알림 삭제  
    `notificationRepository.deleteByAssignment_IdIn(Collections.singletonList(assignmentId))`
  - `QuestionRepository` 주입 후, 해당 과제를 참조하는 질문(questions)의 `assignment_id`만 null로 변경  
    `questionRepository.setAssignmentNullByAssignmentId(assignmentId)`  
  - 순서: 알림 삭제 → 질문 연관 해제 → 과제-문제 관계 삭제 → 과제 삭제
- **파일:** `community/repository/QuestionRepository.java`
  - `@Modifying` 메서드 추가:  
    `int setAssignmentNullByAssignmentId(@Param("assignmentId") Long assignmentId)`  
    - `UPDATE Question q SET q.assignment = null WHERE q.assignment.id = :assignmentId`

### 2. 공지사항 작성자 표시
- **파일:** `notice/dto/NoticeResponseDto.java`
  - 필드 추가: `private String instructorName;` (해당 수업 담당 교수명)
- **파일:** `notice/service/NoticeService.java`
  - `convertToResponse()`에서 `section.getInstructor()`가 있으면 `getName()`으로 `instructorName` 설정 후 DTO에 세팅

