### PR TITLE
fix/issue96/src/

### DIFF
--- a/src/main/java/com/project/handongjudge/community/repository/NotificationRepository.java
+++ b/src/main/java/com/project/handongjudge/community/repository/NotificationRepository.java
@@ -48,5 +48,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     /** 해당 과제들을 참조하는 알림 일괄 삭제 (분반 삭제 시 FK 제약 회피용) */
     void deleteByAssignment_IdIn(List<Long> assignmentIds);
+
+    /** 해당 공지들을 참조하는 알림 일괄 삭제 (분반 삭제 시 notice_id FK 제약 회피용) */
+    void deleteByNotice_IdIn(List<Long> noticeIds);
 }
 

--- a/src/main/java/com/project/handongjudge/grade/repository/GradeRepository.java
+++ b/src/main/java/com/project/handongjudge/grade/repository/GradeRepository.java
@@ -37,5 +37,8 @@ public interface GradeRepository extends JpaRepository<Grade, Long> {
            "WHERE ap.assignment.id = :assignmentId AND ap.problem.id = :problemId")
     Optional<Integer> findProblemPoints(@Param("assignmentId") Long assignmentId,
                                        @Param("problemId") Long problemId);
+
+    /** 분반 삭제 시 FK 제약 회피: 해당 과제들을 참조하는 성적 삭제 */
+    void deleteByAssignment_IdIn(List<Long> assignmentIds);
 }
 

--- a/src/main/java/com/project/handongjudge/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/project/handongjudge/notice/repository/NoticeRepository.java
@@ -26,4 +26,8 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     // 기존 메서드들에 추가
     List<Notice> findByIdIn(List<Long> ids);
+
+    /** 분반 삭제 시 해당 분반 공지 ID 목록 조회 (알림 FK 삭제용) */
+    @Query("SELECT n.id FROM Notice n WHERE n.section.id = :sectionId")
+    List<Long> findNoticeIdsBySectionId(@Param("sectionId") Long sectionId);
 }

--- a/src/main/java/com/project/handongjudge/quiz/repository/QuizGradeRepository.java
+++ b/src/main/java/com/project/handongjudge/quiz/repository/QuizGradeRepository.java
@@ -16,4 +16,7 @@ public interface QuizGradeRepository extends JpaRepository<QuizGrade, Long> {
     );
 
     List<QuizGrade> findByQuizIdAndStudentId(Long quizId, Long studentId);
+
+    /** 해당 퀴즈들에 대한 성적 일괄 삭제 (분반 삭제 시 quiz_id FK 제약 회피용) */
+    void deleteByQuiz_IdIn(List<Long> quizIds);
 }

--- a/src/main/java/com/project/handongjudge/quiz/repository/QuizProblemRepository.java
+++ b/src/main/java/com/project/handongjudge/quiz/repository/QuizProblemRepository.java
@@ -25,7 +25,12 @@ public interface QuizProblemRepository extends JpaRepository<QuizProblem, Long> 
     @Modifying
     @Query("DELETE FROM QuizProblem qp WHERE qp.quiz.id = :quizId")
     void deleteByQuizId(@Param("quizId") Long quizId);
-    
+
+    /** 해당 퀴즈들에 대한 QuizProblem 일괄 삭제 (분반 삭제 시 quiz_id FK 제약 회피용) */
+    @Modifying
+    @Query("DELETE FROM QuizProblem qp WHERE qp.quiz.id IN :quizIds")
+    void deleteByQuiz_IdIn(@Param("quizIds") List<Long> quizIds);
+
     // 문제 ID로 QuizProblem 목록 조회
     List<QuizProblem> findByProblemId(Long problemId);
 }

--- a/src/main/java/com/project/handongjudge/quiz/repository/QuizRepository.java
+++ b/src/main/java/com/project/handongjudge/quiz/repository/QuizRepository.java
@@ -20,6 +20,13 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
     
     @Query("SELECT COUNT(q) FROM Quiz q WHERE q.section.id = :sectionId")
     Integer countBySectionId(@Param("sectionId") Long sectionId);
+
+    /** 분반 삭제 시 해당 분반 퀴즈 ID 목록 조회 */
+    @Query("SELECT q.id FROM Quiz q WHERE q.section.id = :sectionId")
+    List<Long> findQuizIdsBySectionId(@Param("sectionId") Long sectionId);
+
+    /** 분반 삭제 시 해당 분반 퀴즈 일괄 삭제 (section_id FK 제약 회피용) */
+    void deleteBySection_Id(Long sectionId);
 }
 
 

--- a/src/main/java/com/project/handongjudge/section/service/SectionService.java
+++ b/src/main/java/com/project/handongjudge/section/service/SectionService.java
@@ -30,6 +30,10 @@ import com.project.handongjudge.problem.service.ProblemService;
 import com.project.handongjudge.notice.entity.Notice;
 import com.project.handongjudge.notice.repository.NoticeRepository;
 import com.project.handongjudge.community.repository.NotificationRepository;
+import com.project.handongjudge.grade.repository.GradeRepository;
+import com.project.handongjudge.quiz.repository.QuizRepository;
+import com.project.handongjudge.quiz.repository.QuizGradeRepository;
+import com.project.handongjudge.quiz.repository.QuizProblemRepository;
 import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -52,6 +56,10 @@ public class SectionService {
     private final ProblemService problemService;
     private final NoticeRepository noticeRepository;  // ✨ 공지사항 복사용
     private final NotificationRepository notificationRepository;
+    private final GradeRepository gradeRepository;
+    private final QuizRepository quizRepository;
+    private final QuizGradeRepository quizGradeRepository;
+    private final QuizProblemRepository quizProblemRepository;
 
     private String generateEnrollmentCode() {
         // UUID 기반 고유 코드 생성
@@ -133,10 +141,25 @@ public class SectionService {
             throw new IllegalArgumentException("해당 분반을 삭제할 권한이 없습니다");
         }
 
-        // notifications.assignment_id FK 제약 회피: 해당 분반 과제를 참조하는 알림 먼저 삭제
+        // FK 제약 회피: 해당 분반 과제를 참조하는 알림·성적 먼저 삭제
         List<Long> assignmentIds = assignmentRepository.findAssignmentIdsBySectionId(sectionId);
         if (!assignmentIds.isEmpty()) {
             notificationRepository.deleteByAssignment_IdIn(assignmentIds);
+            gradeRepository.deleteByAssignment_IdIn(assignmentIds);
+        }
+
+        // FK 제약 회피: 해당 분반 공지를 참조하는 알림 먼저 삭제 (notice 삭제 시 notifications.notice_id FK 방지)
+        List<Long> noticeIds = noticeRepository.findNoticeIdsBySectionId(sectionId);
+        if (!noticeIds.isEmpty()) {
+            notificationRepository.deleteByNotice_IdIn(noticeIds);
+        }
+
+        // FK 제약 회피: 해당 분반 퀴즈 관련 데이터 선삭제 (quizzes.section_id FK 방지)
+        List<Long> quizIds = quizRepository.findQuizIdsBySectionId(sectionId);
+        if (!quizIds.isEmpty()) {
+            quizProblemRepository.deleteByQuiz_IdIn(quizIds);
+            quizGradeRepository.deleteByQuiz_IdIn(quizIds);
+            quizRepository.deleteBySection_Id(sectionId);
         }
 
         // Section 삭제 (CASCADE 설정에 따라 관련 데이터도 함께 삭제됨)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #96 
1. NotificationRepository.java
추가: 해당 공지들을 참조하는 알림 일괄 삭제 메서드
void deleteByNotice_IdIn(List<Long> noticeIds);
2. NoticeRepository.java
추가: 분반 ID로 공지 ID 목록 조회
@Query("SELECT n.id FROM Notice n WHERE n.section.id = :sectionId")
List<Long> findNoticeIdsBySectionId(@Param("sectionId") Long sectionId);
3. QuizProblemRepository.java
추가: 해당 퀴즈들의 QuizProblem 일괄 삭제
@Modifying
@Query("DELETE FROM QuizProblem qp WHERE qp.quiz.id IN :quizIds")
void deleteByQuiz_IdIn(@Param("quizIds") List<Long> quizIds);
4. QuizGradeRepository.java
추가: 해당 퀴즈들의 퀴즈 성적 일괄 삭제
void deleteByQuiz_IdIn(List<Long> quizIds);
5. QuizRepository.java
추가: 분반별 퀴즈 ID 목록 조회
@Query("SELECT q.id FROM Quiz q WHERE q.section.id = :sectionId")
List<Long> findQuizIdsBySectionId(@Param("sectionId") Long sectionId);
추가: 분반별 퀴즈 일괄 삭제
void deleteBySection_Id(Long sectionId);
6. SectionService.java
의존성 추가:
QuizRepository, QuizGradeRepository, QuizProblemRepository 주입
deleteSection 내부 로직 추가 (순서대로):
공지 참조 알림 선삭제
noticeIds = noticeRepository.findNoticeIdsBySectionId(sectionId)
noticeIds가 비어 있지 않으면
notificationRepository.deleteByNotice_IdIn(noticeIds) 호출
퀴즈 관련 데이터 선삭제
quizIds = quizRepository.findQuizIdsBySectionId(sectionId)
quizIds가 비어 있지 않으면
quizProblemRepository.deleteByQuiz_IdIn(quizIds)
quizGradeRepository.deleteByQuiz_IdIn(quizIds)
quizRepository.deleteBySection_Id(sectionId)
그 다음 기존처럼 sectionRepository.delete(section) 호출
정리:
notifications.notice_id FK → 공지 참조 알림을 먼저 삭제
quizzes.section_id FK → 퀴즈문제 → 퀴즈성적 → 퀴즈 순으로 삭제 후 분반 삭제