### PR TITLE
fix/issue105/src/fix과제-완료율-표시-및-마감-시간-이후에도-제출가능하게

### DIFF
--- a/src/main/java/com/project/handongjudge/assignment/service/AssignmentService.java
+++ b/src/main/java/com/project/handongjudge/assignment/service/AssignmentService.java
@@ -220,11 +220,9 @@ public class AssignmentService {
         // 3. 분반 전체 학생 수
         Integer totalStudents = submissionRepository.countStudentsBySection(sectionId);
 
-        // 4. 과제 제출한 학생 수
-        Integer submittedStudents = submissionRepository.countAllProblemsSubmittedStudents(assignmentId, sectionId);
-        if (submittedStudents == null) {
-            submittedStudents = 0; // null인 경우 0으로 설정
-        }
+        // 4. 과제의 모든 문제를 제출한 학생 수
+        List<Long> submittedUserIds = submissionRepository.findUserIdsWhoSubmittedAllProblems(assignmentId, sectionId);
+        int submittedStudents = (submittedUserIds != null) ? submittedUserIds.size() : 0;
         // 5. 과제 제출률 계산
         Double submissionRate = totalStudents > 0 ?
                 (double) submittedStudents / totalStudents * 100 : 0.0;

--- a/src/main/java/com/project/handongjudge/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/project/handongjudge/submission/repository/SubmissionRepository.java
@@ -32,14 +32,15 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     // 분반별 학생 수 (수강생 수)
     @Query("SELECT COUNT(DISTINCT e.user.id) FROM Enrollment e WHERE e.section.id = :sectionId")
     Integer countStudentsBySection(@Param("sectionId") Long sectionId);
-    @Query("SELECT COUNT(DISTINCT s.user.id) FROM Submission s " +
+    /** 과제의 모든 문제를 1번 이상 제출한 사용자 ID 목록 (제출 현황 인원 수 계산용) */
+    @Query("SELECT s.user.id FROM Submission s " +
             "WHERE s.section.id = :sectionId " +
             "AND s.problem.id IN " +
             "(SELECT ap.problem.id FROM AssignmentProblem ap WHERE ap.assignment.id = :assignmentId) " +
             "GROUP BY s.user.id " +
             "HAVING COUNT(DISTINCT s.problem.id) = " +
             "(SELECT COUNT(ap) FROM AssignmentProblem ap WHERE ap.assignment.id = :assignmentId)")
-    Integer countAllProblemsSubmittedStudents(@Param("assignmentId") Long assignmentId, @Param("sectionId") Long sectionId);
+    List<Long> findUserIdsWhoSubmittedAllProblems(@Param("assignmentId") Long assignmentId, @Param("sectionId") Long sectionId);
 
     // 사용자가 특정 문제를 제출했는지 확인
     @Query("SELECT COUNT(s) > 0 FROM Submission s " +
@@ -107,6 +108,14 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     Optional<LocalDateTime> findFirstAcceptedSubmissionTime(@Param("userId") Long userId,
                                                             @Param("problemId") Long problemId,
                                                             @Param("sectionId") Long sectionId);
+
+    // 특정 학생의 특정 문제에 대한 가장 최근 제출 시간 (지각 여부 판단용)
+    @Query("SELECT MAX(s.submittedAt) FROM Submission s " +
+            "WHERE s.user.id = :userId AND s.problem.id = :problemId " +
+            "AND s.section.id = :sectionId")
+    Optional<LocalDateTime> findLatestSubmissionTime(@Param("userId") Long userId,
+                                                     @Param("problemId") Long problemId,
+                                                     @Param("sectionId") Long sectionId);
 
     // 특정 학생의 특정 문제에 대한 첫 번째 accept된 제출 조회
     @Query("SELECT s FROM Submission s " +

--- a/src/main/java/com/project/handongjudge/submission/service/SubmissionService.java
+++ b/src/main/java/com/project/handongjudge/submission/service/SubmissionService.java
@@ -437,12 +437,7 @@ public class SubmissionService {
                 if (!isManager && !targetAssignment.getActive()) {
                     throw new IllegalArgumentException("해당 과제는 비활성화되어 있어 제출할 수 없습니다");
                 }
-                
-                // 마감일 체크 (관리자/튜터도 과제 마감일이 지나면 제출 불가)
-                if (targetAssignment.getEndDate() != null && now.isAfter(targetAssignment.getEndDate())) {
-                    throw new IllegalArgumentException("과제 마감일이 지났습니다");
-                }
-                
+                // 마감일 지나도 제출 허용 → 지각 제출로 처리 (isOnTime=false, 성적 화면에서 △ 표시)
                 assignmentValid = true;
             }
         }

--- a/src/main/java/com/project/handongjudge/user/dto/StudentProblemStatusDto.java
+++ b/src/main/java/com/project/handongjudge/user/dto/StudentProblemStatusDto.java
@@ -14,4 +14,5 @@ public class StudentProblemStatusDto {
     private String problemTitle;
     private String status;  // "ACCEPTED", "SUBMITTED", "NOT_SUBMITTED"
     private Integer submissionCount;  // 해당 문제에 대한 제출 횟수
+    private Boolean isOnTime;  // 제출 시 마감일 이전 여부 (미제출이면 null)
 }

--- a/src/main/java/com/project/handongjudge/user/service/UserService.java
+++ b/src/main/java/com/project/handongjudge/user/service/UserService.java
@@ -522,37 +522,43 @@ public class UserService {
 
     // UserService의 getStudentAssignmentProblemsStatus 메서드:
     public List<StudentProblemStatusDto> getStudentAssignmentProblemsStatus(Long userId, Long sectionId, Long assignmentId) {
-        // 1. 해당 과제의 모든 문제 가져오기
-        List<Long> problemIds = assignmentProblemRepository.findProblemIdsByAssignmentId(assignmentId);
+        Assignment assignment = assignmentRepository.findById(assignmentId).orElse(null);
+        LocalDateTime endDate = assignment != null ? assignment.getEndDate() : null;
 
+        List<Long> problemIds = assignmentProblemRepository.findProblemIdsByAssignmentId(assignmentId);
         List<StudentProblemStatusDto> problemStatusList = new ArrayList<>();
 
         for (Long problemId : problemIds) {
-            // 2. 문제 정보 가져오기
-            Problem problem = problemRepository.findById(problemId)
-                    .orElse(null);
-
+            Problem problem = problemRepository.findById(problemId).orElse(null);
             if (problem == null) continue;
 
-            // 3. 해당 문제에 대한 학생의 제출 상태 확인
             String status = "NOT_SUBMITTED";
             int submissionCount = submissionRepository.countByUserIdAndProblemId(userId, problemId);
+            Boolean isOnTime = null;
 
             if (submissionCount > 0) {
-                // ACCEPTED("AC")가 있는지 확인
                 int acceptedCount = submissionRepository.countAcceptedByUserIdAndProblemId(userId, problemId);
-
                 status = acceptedCount > 0 ? "ACCEPTED" : "SUBMITTED";
+
+                if (endDate != null) {
+                    Optional<LocalDateTime> refTime = acceptedCount > 0
+                            ? submissionRepository.findFirstAcceptedSubmissionTime(userId, problemId, sectionId)
+                            : submissionRepository.findLatestSubmissionTime(userId, problemId, sectionId);
+                    isOnTime = refTime
+                            .map(t -> !t.isAfter(endDate))
+                            .orElse(false);
+                } else {
+                    isOnTime = true;
+                }
             }
 
-            StudentProblemStatusDto statusDto = StudentProblemStatusDto.builder()
+            problemStatusList.add(StudentProblemStatusDto.builder()
                     .problemId(problemId)
                     .problemTitle(problem.getTitle())
                     .status(status)
                     .submissionCount(submissionCount)
-                    .build();
-
-            problemStatusList.add(statusDto);
+                    .isOnTime(isOnTime)
+                    .build());
         }
 
         return problemStatusList;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #105 
### 1. 문제 설명(description) 중복 제거
- **ProblemFileUtil.java**: `stripDuplicateInputOutputExample(String description)` static 메서드 추가  
  - API/DB에 "## 입력 형식"~"## 예제" 블록이 두 번 들어 있는 경우, 두 번째 블록부터 제거해 반환
- **ProblemService.java**: 아래 응답 시 `description`에 위 메서드 적용  
  - 단건 조회 `getProblem()`  
  - 과제용 `convertToProblemResponse()`  
  - 문제 복사 시 새 문제의 description

### 2. 지각 제출 허용
- **SubmissionService.java**: `validateSubmission()`  
  - 과제 마감일이 지나도 제출 가능하도록 **마감일 초과 시 예외 제거**  
  - 마감 후 제출은 그대로 저장되고, 성적 쪽에서 `isOnTime=false`로 처리

### 3. 학생 과제 문제 상태에 제출 시각(지각 여부) 반영
- **StudentProblemStatusDto.java**: `Boolean isOnTime` 필드 추가 (미제출이면 null)
- **SubmissionRepository.java**:  
  - `findLatestSubmissionTime(userId, problemId, sectionId)` 추가  
  - `countAllProblemsSubmittedStudents` 제거 → `findUserIdsWhoSubmittedAllProblems(assignmentId, sectionId)` 추가 (반환: `List<Long>`)
- **UserService.java**: `getStudentAssignmentProblemsStatus()`  
  - 과제 `endDate` 조회 후, 문제별로 첫 AC 제출 시각 또는 최근 제출 시각과 비교해 `isOnTime` 설정

### 4. 과제 제출 통계(모든 문제 완료 인원) 수정
- **AssignmentService.java**: `getAssignmentSubmissionStats()`  
  - `countAllProblemsSubmittedStudents` 대신 `findUserIdsWhoSubmittedAllProblems()`로 **제출한 사용자 ID 목록** 조회 후 `submittedStudents = list.size()` 로 계산  
  - 2명이면 2명으로 정확히 표시되도록 수정