### PR TITLE
feat/issue-118/src/20260310feedbackdone

### DIFF
--- a/src/main/java/com/project/handongjudge/problem/service/ProblemService.java
+++ b/src/main/java/com/project/handongjudge/problem/service/ProblemService.java
@@ -91,8 +91,10 @@ public class ProblemService {
         User instructor = userRepository.findById(instructorId)
                 .orElseThrow(() -> new IllegalArgumentException("Instructor not found: " + instructorId));
 
+        String originalTitle = ensureOriginalTitle(request.getTitle());
+
         Problem problem = Problem.builder()
-                .title(request.getTitle())
+                .title(originalTitle)
                 .description(description)
                 .domjudgeProblemId(domjudgeProblemId)
                 .timeLimit((Double) limits.get("timeLimit"))
@@ -155,8 +157,10 @@ public class ProblemService {
                 ? request.getDifficulty().trim()
                 : "1";
 
+        String originalTitle = ensureOriginalTitle(request.getTitle());
+
         Problem problem = Problem.builder()
-                .title(request.getTitle())
+                .title(originalTitle)
                 .description(fullDescription)
                 .difficulty(difficulty)
                 .domjudgeProblemId(domjudgeProblemId)
@@ -169,7 +173,7 @@ public class ProblemService {
                 .build();
 
         problemRepository.save(problem);
-        log.info("문제 생성 완료: ID={}, Title={}", problem.getId(), request.getTitle());
+        log.info("문제 생성 완료: ID={}, Title={}", problem.getId(), originalTitle);
 
         return problem.getId();
     }
@@ -467,10 +471,16 @@ public class ProblemService {
         // byte[]를 MultipartFile로 변환
         MultipartFile originalZipFile = new ByteArrayMultipartFile(originalZipData, "problem.zip");
 
-        // 새 문제 제목
-        String problemTitle = (newTitle != null && !newTitle.trim().isEmpty())
-                ? newTitle
-                : sourceProblem.getTitle() + " (복사본)";
+        // 새 문제 제목: 지정값이 없으면 원본에서 "_오리지널"만 제거 (복사본 접미사 사용 안 함)
+        String problemTitle;
+        if (newTitle != null && !newTitle.trim().isEmpty()) {
+            problemTitle = newTitle.trim();
+        } else {
+            problemTitle = stripOriginalSuffix(sourceProblem.getTitle());
+            if (problemTitle.isEmpty()) {
+                problemTitle = sourceProblem.getTitle();
+            }
+        }
 
         // 고유한 externalid 생성 (문제 복사 시에는 타임스탬프만 사용)
         String externalId = "problem-" + System.currentTimeMillis();
@@ -506,6 +516,25 @@ public class ProblemService {
                 sourceProblemId, savedProblem.getId(), problemTitle);
 
         return savedProblem.getId();
+    }
+
+    /** 문제 생성 시 저장 제목: "_오리지널" 접미사가 없으면 붙인다 */
+    private static String ensureOriginalTitle(String title) {
+        if (title == null) return "_오리지널";
+        String t = title.trim();
+        if (t.isEmpty()) return "_오리지널";
+        if (t.endsWith("_오리지널")) return t;
+        return t + "_오리지널";
+    }
+
+    /** 복사 시 사용할 제목: "_오리지널" 접미사를 제거한다 */
+    private static String stripOriginalSuffix(String title) {
+        if (title == null) return "";
+        String t = title.trim();
+        if (t.endsWith("_오리지널")) {
+            return t.substring(0, t.length() - "_오리지널".length()).trim();
+        }
+        return t;
     }
 
     /**

--- a/src/main/java/com/project/handongjudge/user/dto/StudentProblemStatusDto.java
+++ b/src/main/java/com/project/handongjudge/user/dto/StudentProblemStatusDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -15,4 +17,8 @@ public class StudentProblemStatusDto {
     private String status;  // "ACCEPTED", "SUBMITTED", "NOT_SUBMITTED"
     private Integer submissionCount;  // 해당 문제에 대한 제출 횟수
     private Boolean isOnTime;  // 제출 시 마감일 이전 여부 (미제출이면 null)
+    /** 제출 시각 (미제출이면 null) */
+    private LocalDateTime submittedAt;
+    /** 지각 제출 시 마감일 대비 늦은 분 수 (제시간 제출·미제출이면 null) */
+    private Integer minutesLate;
 }

--- a/src/main/java/com/project/handongjudge/user/service/UserService.java
+++ b/src/main/java/com/project/handongjudge/user/service/UserService.java
@@ -31,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.project.handongjudge.domjudge.service.DomjudgeService;
 import java.util.ArrayList;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -535,20 +536,29 @@ public class UserService {
             String status = "NOT_SUBMITTED";
             int submissionCount = submissionRepository.countByUserIdAndProblemId(userId, problemId);
             Boolean isOnTime = null;
+            LocalDateTime submittedAt = null;
+            Integer minutesLate = null;
 
             if (submissionCount > 0) {
                 int acceptedCount = submissionRepository.countAcceptedByUserIdAndProblemId(userId, problemId);
                 status = acceptedCount > 0 ? "ACCEPTED" : "SUBMITTED";
 
-                if (endDate != null) {
-                    Optional<LocalDateTime> refTime = acceptedCount > 0
-                            ? submissionRepository.findFirstAcceptedSubmissionTime(userId, problemId, sectionId)
-                            : submissionRepository.findLatestSubmissionTime(userId, problemId, sectionId);
-                    isOnTime = refTime
-                            .map(t -> !t.isAfter(endDate))
-                            .orElse(false);
+                Optional<LocalDateTime> refTime = acceptedCount > 0
+                        ? submissionRepository.findFirstAcceptedSubmissionTime(userId, problemId, sectionId)
+                        : submissionRepository.findLatestSubmissionTime(userId, problemId, sectionId);
+
+                if (refTime.isPresent()) {
+                    submittedAt = refTime.get();
+                    if (endDate != null) {
+                        isOnTime = !submittedAt.isAfter(endDate);
+                        if (submittedAt.isAfter(endDate)) {
+                            minutesLate = (int) ChronoUnit.MINUTES.between(endDate, submittedAt);
+                        }
+                    } else {
+                        isOnTime = true;
+                    }
                 } else {
-                    isOnTime = true;
+                    if (endDate != null) isOnTime = false;
                 }
             }
 
@@ -558,6 +568,8 @@ public class UserService {
                     .status(status)
                     .submissionCount(submissionCount)
                     .isOnTime(isOnTime)
+                    .submittedAt(submittedAt)
+                    .minutesLate(minutesLate)
                     .build());
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #118 

## 📝작업 내용
# Backend 변경 사항 (Git Issue용)

## 1. 문제 생성 시 제목에 `_오리지널` 접미사
- **ProblemService**
  - `ensureOriginalTitle(title)`: 제목이 이미 `_오리지널`로 끝나지 않으면 접미사 추가
  - **createProblem** (ZIP/폼 생성 공통): 저장 시 `ensureOriginalTitle(request.getTitle())` 사용 → DB에는 `"제목_오리지널"` 형태로 저장

## 2. 문제 복사 시 제목 처리 (복사본 접미사 제거)
- **ProblemService.copyProblem**
  - `stripOriginalSuffix(title)`: 제목 끝의 `_오리지널` 제거
  - 새 제목(`newTitle`)을 넘기지 않으면: 원본 제목에서 `_오리지널`만 제거한 값을 사용, **"(복사본)" 접미사는 더 이상 붙이지 않음**
  - 과제/퀴즈에 문제 추가 시 복사된 문제는 "제목"만 가지게 됨

## 3. 학생 과제 문제 상태 API – 제출 시각 · 지각 분
- **StudentProblemStatusDto**
  - `submittedAt` (LocalDateTime): 제출 시각, 미제출이면 null
  - `minutesLate` (Integer): 지각 제출 시 마감일 대비 늦은 분 수, 제시간/미제출이면 null
- **UserService.getStudentAssignmentProblemsStatus**
  - 제출이 있으면 `findFirstAcceptedSubmissionTime` / `findLatestSubmissionTime`으로 제출 시각 조회 후 `submittedAt` 설정
  - 마감일(`endDate`) 이후 제출이면 `ChronoUnit.MINUTES.between(endDate, submittedAt)`으로 `minutesLate` 설정
  - 응답에 `submittedAt`, `minutesLate` 포함 (FE 과제 페이지 제출 시간·지각 표기용)

## 4. 기타
- 성적 API(GradeServiceImpl, QuizService)의 `ProblemGradeDTO`는 기존에도 `setSubmittedAt` 호출 중. 제출 시각이 null이면 DB/도메인 쪽 `Submission.submittedAt` 또는 조회 경로 확인 필요.
