### PR TITLE
fix/issue-126/src/문제집생성일추가

### DIFF
--- a/src/main/java/com/project/handongjudge/problem/dto/ProblemInSetDto.java
+++ b/src/main/java/com/project/handongjudge/problem/dto/ProblemInSetDto.java
@@ -3,6 +3,8 @@ package com.project.handongjudge.problem.dto;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Data
 @Builder
 public class ProblemInSetDto {
@@ -10,5 +12,6 @@ public class ProblemInSetDto {
     private String title;
     private String difficulty;
     private Integer order;  // 문제집 내 순서
+    private LocalDateTime createdAt;
 }
 

--- a/src/main/java/com/project/handongjudge/problem/service/ProblemSetService.java
+++ b/src/main/java/com/project/handongjudge/problem/service/ProblemSetService.java
@@ -57,6 +57,7 @@ public class ProblemSetService {
                         .title(psp.getProblem().getTitle())
                         .difficulty(psp.getProblem().getDifficulty())
                         .order(psp.getProblemOrder())
+                        .createdAt(psp.getProblem().getCreatedAt())
                         .build())
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #126 

## 📝작업 내용

## 1. 요약 (한 줄)
**성적·진행률·코드 조회에서 “첫 AC 제출”이 아니라 “해당 문제의 가장 마지막 제출(시간 기준)”을 기준**으로 판별·표시하도록 변경.  
추가로 **학생 식별자를 이메일 대신 학번(`studentId`) 우선**으로 노출·정렬.
---
## 2. `SubmissionRepository.java`
### 추가 메서드
- **`findLatestSubmissionsByUserAndProblem(userId, problemId, sectionId, Pageable)`**
  - JPQL: `user` + `problem` + `section` 일치하는 `Submission` 전체 중 **`submittedAt DESC`** 정렬.
  - `PageRequest.of(0, 1)`과 함께 쓰면 **가장 최근 제출 1건**만 조회.
  - 주석: 성적·표시용, **결과(AC 여부) 무관**.
### 기존과의 차이
- 기존: 여러 곳에서 `findAcceptedSubmissionsByUserAndProblem` → **AC만**, 보통 “첫 번째”만 쓰는 패턴.
- 변경 후: **마지막 제출 1건**을 가져와 점수/결과/제출 시각/정답 여부 판단에 사용.
---
## 3. `GradeServiceImpl.java`
### 동작 변경
- **수동 성적 입력/조회 후 DTO 변환**, **과제별 성적 집계**, **학생별 과제 성적**, **단건 성적 조회** 등에서  
  제출 조회를 전부 **`findLatestSubmission` 헬퍼**로 통일.
### `findLatestSubmission(userId, problemId, sectionId)`
- 내부에서 `submissionRepository.findLatestSubmissionsByUserAndProblem(..., PageRequest.of(0, 1))` 호출 후 `Optional<Submission>` 반환.
### 비즈니스 영향
- **제출 여부 / `submittedAt` / 정시 여부(`isOnTime`) / `result` / AC면 1점** 등이 **항상 “마지막 제출” 기준**.
- 마지막 제출이 WA여도: `submitted=true`, `result=WA`, 점수 0 등으로 표시 (이전에는 “첫 AC”만 보면 이후 WA는 반영 방식이 달랐을 수 있음).
---
## 4. `QuizService.java`
### 퀴즈 성적 집계 (문제별)
- `findAcceptedSubmissionsByUserAndProblem` + `findFirst()` 제거.
- **`findLatestSubmissionsByUserAndProblem(..., Page.of(0,1))`** → 최신 1건으로 `submittedAt`, `isOnTime`, `result`, AC 시 1점 반영.
### 퀴즈 성적 저장 후 응답 DTO
- 동일하게 **최신 제출 1건**을 붙여 `toQuizGradeResponseDTO`에 전달.
### 학생 정답 코드 조회 API (퀴즈 내 문제)
- **이전**: AC 제출 목록 중 첫 건 없으면 `"해당 학생은 이 문제를 아직 정답으로 제출하지 않았습니다"`.
- **이후**: 최신 제출 1건; **없으면** `"해당 학생의 제출 기록이 없습니다"`.
- 반환 코드/언어/결과는 **마지막 제출** 기준 (AC가 아니어도 마지막 제출 코드가 나감).
---
## 5. `AssignmentService.java`
### 과제 진행률/학생 목록 (`StudentProgressResponse` 등)
- **`studentId` 필드**: 기존 `student.getEmail()` → **학번 `student.getStudentId()`**, null/공백이면 `"-"`.
- 정렬: 이메일 순 → **`studentId` 대소문자 무시 문자열 정렬** (`String.CASE_INSENSITIVE_ORDER`).
### 과제 내 “학생 정답 코드 조회” (문제별)
- **이전**: AC 제출 중 첫 건, 없으면 정답 미제출 예외.
- **이후**: **최신 제출 1건**; 없으면 `"해당 학생의 제출 기록이 없습니다"`.
- 응답의 `studentId`: 학번 우선, 없으면 이메일.
---
## 6. 테스트·검증 체크리스트 (수동)
- [ ] 과제: 한 문제에 여러 번 제출(AC → WA) 시 성적/진행 화면이 **마지막 제출**과 일치하는지
- [ ] 퀴즈: 동일 시나리오
- [ ] 튜터 “정답 코드 보기”: 마지막 제출이 WA일 때 **그 코드**가 보이는지 (의도한 UX인지 확인)
- [ ] 진행률 리스트: 학번 표시 및 학번 정렬
- [ ] 제출 이력 없는 학생: 예외 메시지가 **“제출 기록이 없습니다”**로 바뀐 부분 UI/문구 확인
---
## 7. (같은 브랜치/후속 로컬 작업으로 이슈에 추가 가능) 문제집 상세 API

- **`ProblemInSetDto`**: `createdAt` (`LocalDateTime`) 필드 추가.
- **`ProblemSetService.getProblemSet`**: 각 문제에 `psp.getProblem().getCreatedAt()` 매핑.
- **목적**: FE 과제 추가 시 문제집에서 문제 목록을 띄울 때 **생성일** 표시.
-## 개요
튜터 흐름 중 **문제집 상세 API** 응답에 포함되는 문제 목록 DTO에 **문제 생성일(`createdAt`)** 을 추가했습니다.  
프론트에서 과제에 문제 추가 시 **문제집 탭**으로 문제를 불러올 때 생성일을 표시하기 위함입니다.

---

## 배경 / 문제
- 문제집 상세 조회 시 내려주는 `ProblemInSetDto`는 `id`, `title`, `difficulty`, `order`만 포함.
- 과제 추가 모달에서 문제집을 선택해 문제 목록을 띄우면 **생성일 필드가 없어** UI에 생성일을 그릴 수 없었음.

---

## 변경 파일

### 1. `problem/dto/ProblemInSetDto.java`
- **추가 필드**: `private LocalDateTime createdAt;`
- **import**: `java.time.LocalDateTime`
- Lombok `@Builder`, `@Data` 유지 → JSON 직렬화 시 Jackson이 `LocalDateTime`을 ISO-8601 형태 등으로 직렬화 (프로젝트 Jackson 설정에 따름).

### 2. `problem/service/ProblemSetService.java` — `getProblemSet(Long problemSetId, Long instructorId)`
- `ProblemSetProblem` 스트림에서 `ProblemInSetDto` 빌드 시 다음 매핑 추가:
  - `.createdAt(psp.getProblem().getCreatedAt())`
- 엔티티 `Problem`에 이미 `createdAt` 필드가 있으므로 추가 쿼리 없이 기존 로딩된 `psp.getProblem()`에서 조회.

---

## API 동작 (변경 후)
- **엔드포인트**: (기존과 동일) 문제집 상세 — 예: `GET .../problem-sets/{id}` 형태 (실제 경로는 `ProblemSetController` 참고).
- **응답 내 `problems[]` 각 항목**에 `createdAt` 포함 가능.
- **하위 호환**: 필드 추가만 하므로 기존 클라이언트는 무시 가능; 신규 FE는 생성일 표시에 사용.

---

## 테스트 체크리스트
- [x] 문제집에 문제가 1개 이상 있을 때 상세 API 응답의 `problems[].createdAt` 존재 및 값 일치
- [x] `createdAt`이 null인 오래된 데이터(있다면) 직렬화/FE 표시 확인

---

## 관련 FE 이슈
- 과제 추가 모달 — 문제집 경로에서 카드에 `생성일` 표시 (동일 스프린트/PR에서 묶여 있을 수 있음).
---
## 변경 파일 목록 (PR #128 본문)
| 파일 | 역할 |
|------|------|
| `SubmissionRepository.java` | 최신 제출 1건 조회 쿼리 추가 |
| `GradeServiceImpl.java` | 성적 로직 전반을 마지막 제출 기준으로 |
| `QuizService.java` | 퀴즈 성적·코드 조회를 마지막 제출 기준으로 |
| `AssignmentService.java` | 진행률 학번 표시/정렬, 코드 조회 마지막 제출 기준 |
