### PR TITLE
fix: remove direct quizRepository usage from QuizController

### DIFF
--- a/src/main/java/com/project/handongjudge/quiz/controller/QuizController.java
+++ b/src/main/java/com/project/handongjudge/quiz/controller/QuizController.java
@@ -1,10 +1,8 @@
 package com.project.handongjudge.quiz.controller;
 
 import com.project.handongjudge.assignment.dto.StudentAcceptedCodeResponse;
-import com.project.handongjudge.grade.dto.StudentGradeSummaryDTO;
-import com.project.handongjudge.quiz.entity.Quiz;
-import com.project.handongjudge.quiz.repository.QuizRepository;
 import com.project.handongjudge.assignment.dto.StudentProgressResponse;
+import com.project.handongjudge.grade.dto.StudentGradeSummaryDTO;
 import com.project.handongjudge.quiz.dto.*;
 import com.project.handongjudge.quiz.entity.Quiz;
 import com.project.handongjudge.quiz.service.QuizService;
@@ -187,8 +185,7 @@ public class QuizController {
             Authentication authentication
     ) {
         Long tutorId = Long.parseLong(authentication.getName());
-        Quiz quiz = quizRepository.findById(quizId)
-                .orElseThrow(() -> new IllegalArgumentException("Quiz not found"));
+        Quiz quiz = quizService.findById(quizId);
         List<StudentGradeSummaryDTO> grades = quizService.getQuizGrades(quizId, sectionId, tutorId, false);
 
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -271,7 +268,7 @@ public class QuizController {
             Authentication authentication
     ) {
         Long tutorId = Long.parseLong(authentication.getName());
-        List<Quiz> quizzes = quizRepository.findBySectionIdOrderByStartTimeDesc(sectionId);
+        List<Quiz> quizzes = quizService.findBySectionId(sectionId);
 
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
              ZipOutputStream zos = new ZipOutputStream(baos)) {

--- a/src/main/java/com/project/handongjudge/quiz/service/QuizService.java
+++ b/src/main/java/com/project/handongjudge/quiz/service/QuizService.java
@@ -158,6 +158,17 @@ public class QuizService {
      * Quiz 상세 정보 조회
      */
     @Transactional(readOnly = true)
+    public Quiz findById(Long quizId) {
+        return quizRepository.findById(quizId)
+                .orElseThrow(() -> new IllegalArgumentException("Quiz not found: " + quizId));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Quiz> findBySectionId(Long sectionId) {
+        return quizRepository.findBySectionIdOrderByStartTimeDesc(sectionId);
+    }
+
+    @Transactional(readOnly = true)
     public QuizResponse getQuizInfo(Long quizId, Long userId) {
         Quiz quiz = quizRepository.findById(quizId)
                 .orElseThrow(() -> new IllegalArgumentException("Quiz not found"));


### PR DESCRIPTION
Replace quizRepository.findById() and findBySectionIdOrderByStartTimeDesc() calls in QuizController with quizService.findById() and findBySectionId() to fix compilation error after merge conflict resolution.


## #️⃣연관된 이슈

> #148 