### PR TITLE
feat: QuizService: addProblemToQuiz(sectionId, quizId, problemId, userId) 추가 퀴즈가 해당 sectionId에 속하는지 확인 isManager 권한 확인

### DIFF
--- a/src/main/java/com/project/handongjudge/quiz/controller/QuizController.java
+++ b/src/main/java/com/project/handongjudge/quiz/controller/QuizController.java
@@ -169,6 +169,21 @@ public class QuizController {
     }
 
     /**
+     * 퀴즈에 문제 추가 (단건, 기존 연결 유지)
+     */
+    @PostMapping("/{quizId}/problems/{problemId}")
+    public ResponseEntity<Void> addProblemToQuiz(
+            @PathVariable Long sectionId,
+            @PathVariable Long quizId,
+            @PathVariable Long problemId,
+            Authentication authentication
+    ) {
+        Long userId = Long.parseLong(authentication.getName());
+        quizService.addProblemToQuiz(sectionId, quizId, problemId, userId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    /**
      * 퀴즈에서 문제 제거
      */
     @DeleteMapping("/{quizId}/problems/{problemId}")

--- a/src/main/java/com/project/handongjudge/quiz/service/QuizService.java
+++ b/src/main/java/com/project/handongjudge/quiz/service/QuizService.java
@@ -447,6 +447,48 @@ public class QuizService {
     }
 
     /**
+     * 퀴즈에 문제 한 건만 추가 (기존 {@link QuizProblem} 행은 유지).
+     * 과제 {@code AssignmentProblemService.addProblemToAssignment}와 동일한 패턴.
+     */
+    public void addProblemToQuiz(Long sectionId, Long quizId, Long problemId, Long userId) {
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new IllegalArgumentException("Quiz not found"));
+        if (!quiz.getSection().getId().equals(sectionId)) {
+            throw new IllegalArgumentException("해당 퀴즈는 이 분반에 속하지 않습니다");
+        }
+        if (!sectionRoleService.isManager(userId, sectionId)) {
+            throw new IllegalArgumentException("해당 코딩 테스트를 수정할 권한이 없습니다");
+        }
+
+        if (quizProblemRepository.findByQuizIdAndProblemId(quizId, problemId).isPresent()) {
+            throw new IllegalArgumentException("이미 이 코딩 테스트에 포함된 문제입니다");
+        }
+
+        Problem problem = problemRepository.findById(problemId)
+                .orElseThrow(() -> new IllegalArgumentException("문제 ID 없음: " + problemId));
+
+        List<QuizProblem> existing = quizProblemRepository.findByQuizIdOrderByProblemOrderAsc(quizId);
+        int nextOrder = 1;
+        if (!existing.isEmpty()) {
+            nextOrder = existing.stream()
+                    .mapToInt(qp -> qp.getProblemOrder() != null ? qp.getProblemOrder() : 0)
+                    .max()
+                    .orElse(0) + 1;
+        }
+
+        QuizProblem qp = QuizProblem.builder()
+                .quiz(quiz)
+                .problem(problem)
+                .problemOrder(nextOrder)
+                .points(1)
+                .build();
+        quizProblemRepository.save(qp);
+
+        Long contestId = quiz.getSection().getId();
+        domjudgeService.addProblemToContest(contestId, problem.getDomjudgeProblemId());
+    }
+
+    /**
      * 퀴즈에서 문제 제거
      */
     public void removeProblemFromQuiz(Long quizId, Long problemId, Long instructorId) {


### PR DESCRIPTION
QuizService: addProblemToQuiz(sectionId, quizId, problemId, userId) 추가 퀴즈가 해당 sectionId에 속하는지 확인
isManager 권한 확인
이미 같은 problemId가 퀴즈에 있으면 예외
기존 문제들의 problemOrder 최댓값 + 1로 새 행만 저장, points 1
DOMjudge addProblemToContest만 해당 문제에 대해 호출

(QuizController):
POST /api/sections/{sectionId}/quizzes/{quizId}/problems/{problemId} → 201 Created 기존 DELETE 동일 경로와 HTTP 메서드만 다름
