### PR TITLE
fix/issue0184/184-fix성적코드집및제출처리

### DIFF
--- a/src/main/java/com/project/handongjudge/assignment/controller/AssignmentController.java
+++ b/src/main/java/com/project/handongjudge/assignment/controller/AssignmentController.java
@@ -21,10 +21,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import com.project.handongjudge.assignment.dto.StudentProgressResponse;
 import com.project.handongjudge.assignment.dto.StudentAcceptedCodeResponse;
+import com.project.handongjudge.common.ZipExportPathUtils;
+import com.project.handongjudge.common.time.SubmissionDeadlineComparison;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -201,7 +202,7 @@ public class AssignmentController {
 
     /**
      * 섹션의 전체 과제 제출 코드 ZIP 다운로드
-     * 구조: 전체과제/{과제명}/{문제}/{학번}/코드파일
+     * 구조: 전체과제/{과제명}/{문제}/{학번_이름}/코드파일
      */
     @GetMapping("/export-zip-all")
     public ResponseEntity<byte[]> exportAllAssignmentCodesZip(
@@ -232,11 +233,11 @@ public class AssignmentController {
                         }
 
                         String safeAssignment = sanitize(assignment.getTitle());
-                        String safeStudent = sanitize(student.getStudentId());
+                        String safeStudent = ZipExportPathUtils.studentFolderSegment(student);
                         String safeProblem = sanitize(pg.getProblemTitle());
                         String ext = languageToExt(codeResponse.getLanguage());
                         String problemFolder = pg.getProblemId() + "_" + safeProblem;
-                        String baseCodePath = "전체과제/" + safeAssignment + "/" + problemFolder + "/" + safeStudent + "/" + safeProblem + "_" + fileTime(pg.getSubmittedAt());
+                        String baseCodePath = "전체과제/" + safeAssignment + "/" + problemFolder + "/" + safeStudent + "/" + safeProblem + "_" + SubmissionDeadlineComparison.submittedAtKstForZipPath(pg.getSubmittedAt());
                         String codePath = uniquePath(
                                 baseCodePath,
                                 ext,
@@ -260,10 +261,10 @@ public class AssignmentController {
                                 .append(csvEsc(pg.getProblemTitle())).append(',')
                                 .append(csvEsc(withSubmittedAt(pg.getProblemTitle(), pg.getSubmittedAt()))).append(',')
                                 .append(csvEsc(pg.getResult())).append(',')
-                                .append(csvEsc(toStr(pg.getSubmittedAt()))).append(',')
-                                .append(csvEsc(toStr(assignment.getEndDate()))).append(',')
+                                .append(csvEsc(SubmissionDeadlineComparison.formatSubmittedAtKstCsv(pg.getSubmittedAt()))).append(',')
+                                .append(csvEsc(SubmissionDeadlineComparison.formatDueKstCsv(assignment.getEndDate()))).append(',')
                                 .append(Boolean.TRUE.equals(pg.getIsOnTime()) ? "true" : "false").append(',')
-                                .append(csvEsc(toLateText(pg.getSubmittedAt(), assignment.getEndDate()))).append(',')
+                                .append(csvEsc(SubmissionDeadlineComparison.lateDurationText(pg.getSubmittedAt(), assignment.getEndDate()))).append(',')
                                 .append(csvEsc(codePath))
                                 .append('\n');
                     }
@@ -296,35 +297,11 @@ public class AssignmentController {
         return value.replaceAll("[^a-zA-Z0-9가-힣._-]", "_");
     }
 
-    private static String toStr(LocalDateTime dt) {
-        return dt == null ? "" : dt.toString();
-    }
-
-    private static String toLateText(LocalDateTime submittedAt, LocalDateTime dueAt) {
-        if (submittedAt == null || dueAt == null) return "";
-        Duration d = Duration.between(dueAt, submittedAt);
-        if (d.isNegative() || d.isZero()) return "";
-        long minutes = d.toMinutes();
-        long days = minutes / (60 * 24);
-        long hours = (minutes % (60 * 24)) / 60;
-        long mins = minutes % 60;
-        StringBuilder sb = new StringBuilder();
-        if (days > 0) sb.append(days).append("일 ");
-        if (hours > 0) sb.append(hours).append("시간 ");
-        if (mins > 0 || sb.length() == 0) sb.append(mins).append("분");
-        return sb.toString().trim();
-    }
-
     private static String withSubmittedAt(String base, LocalDateTime submittedAt) {
         String value = base == null ? "" : base;
-        String submitted = toStr(submittedAt);
+        String submitted = SubmissionDeadlineComparison.formatSubmittedAtKstCsv(submittedAt);
         if (submitted.isEmpty()) return value;
         return value + " (" + submitted + ")";
-    }
-
-    private static String fileTime(LocalDateTime dt) {
-        if (dt == null) return "unknown_time";
-        return dt.toString().replace(":", "-").replace(".", "-");
     }
 
     private static String languageToExt(String language) {

--- a/src/main/java/com/project/handongjudge/common/ZipExportPathUtils.java
+++ b/src/main/java/com/project/handongjudge/common/ZipExportPathUtils.java
@@ -1,0 +1,40 @@
+package com.project.handongjudge.common;
+
+import com.project.handongjudge.grade.dto.StudentGradeSummaryDTO;
+
+/**
+ * ZIP보내기 등에서 사용하는 경로 세그먼트 정규화.
+ */
+public final class ZipExportPathUtils {
+
+    private ZipExportPathUtils() {
+    }
+
+    /**
+     * 문제 폴더 아래 학생 디렉터리명: 학번_이름 (이름 없으면 학번만).
+     */
+    public static String studentFolderSegment(StudentGradeSummaryDTO student) {
+        if (student == null) {
+            return "unknown";
+        }
+        return studentFolderSegment(student.getStudentId(), student.getStudentName());
+    }
+
+    public static String studentFolderSegment(String studentId, String studentName) {
+        String sid = studentId == null ? "" : studentId.trim();
+        String nm = studentName == null ? "" : studentName.trim();
+        if (sid.isEmpty() && nm.isEmpty()) {
+            return "unknown";
+        }
+        String combined = nm.isEmpty() ? sid : (sid.isEmpty() ? nm : sid + "_" + nm);
+        return sanitizePathSegment(combined);
+    }
+
+    public static String sanitizePathSegment(String s) {
+        String value = s == null ? "unknown" : s.trim();
+        if (value.isEmpty()) {
+            return "unknown";
+        }
+        return value.replaceAll("[^a-zA-Z0-9가-힣._-]", "_");
+    }
+}

--- a/src/main/java/com/project/handongjudge/common/time/SubmissionDeadlineComparison.java
+++ b/src/main/java/com/project/handongjudge/common/time/SubmissionDeadlineComparison.java
@@ -1,0 +1,102 @@
+package com.project.handongjudge.common.time;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * 제출 시각과 마감(종료) 시각 비교.
+ * <p>
+ * {@code submittedAt}은 DB에 KST 벽시계({@code LocalDateTime.now(Asia/Seoul)})로 저장되고,
+ * {@code dueAt}은 프론트 {@code toISOString()} → Jackson UTC 파싱으로 저장된 값이므로
+ * UTC 벽시계로 해석해 {@link Instant}로 맞춘 뒤 비교한다.
+ */
+public final class SubmissionDeadlineComparison {
+
+    private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
+    private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+
+    /** CSV·화면과 동일하게 한국 시간으로 보이도록 */
+    private static final DateTimeFormatter CSV_KST = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    /** ZIP 경로용 (파일시스템 안전 문자) */
+    private static final DateTimeFormatter ZIP_KST = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
+
+    private SubmissionDeadlineComparison() {}
+
+    /** 제출 시각: DB KST 벽시계 → 그대로 한국 시각 문자열 */
+    public static String formatSubmittedAtKstCsv(LocalDateTime kstWallClock) {
+        if (kstWallClock == null) {
+            return "";
+        }
+        return CSV_KST.format(kstWallClock.atZone(KST_ZONE).toLocalDateTime());
+    }
+
+    /** 마감·종료: DB UTC 벽시계 → 한국 시각으로 변환해 문자열 */
+    public static String formatDueKstCsv(LocalDateTime utcWallClock) {
+        if (utcWallClock == null) {
+            return "";
+        }
+        return CSV_KST.format(
+                utcWallClock.atZone(UTC_ZONE).withZoneSameInstant(KST_ZONE).toLocalDateTime());
+    }
+
+    /** 제출 시각 기반 ZIP 안 파일명 조각 (한국 시각) */
+    public static String submittedAtKstForZipPath(LocalDateTime kstWallClock) {
+        if (kstWallClock == null) {
+            return "unknown_time";
+        }
+        return ZIP_KST.format(kstWallClock.atZone(KST_ZONE).toLocalDateTime());
+    }
+
+    public static boolean isSubmittedOnTime(LocalDateTime submittedAt, LocalDateTime dueAt) {
+        if (submittedAt == null || dueAt == null) {
+            return true;
+        }
+        Instant submittedInstant = submittedAt.atZone(KST_ZONE).toInstant();
+        Instant dueInstant = dueAt.atZone(UTC_ZONE).toInstant();
+        return !submittedInstant.isAfter(dueInstant);
+    }
+
+    /** 정시·조기 제출이면 빈 문자열, 지각이면 일/시간/분 텍스트 */
+    public static String lateDurationText(LocalDateTime submittedAt, LocalDateTime dueAt) {
+        if (submittedAt == null || dueAt == null) {
+            return "";
+        }
+        Instant submittedInstant = submittedAt.atZone(KST_ZONE).toInstant();
+        Instant dueInstant = dueAt.atZone(UTC_ZONE).toInstant();
+        if (!submittedInstant.isAfter(dueInstant)) {
+            return "";
+        }
+        long minutes = ChronoUnit.MINUTES.between(dueInstant, submittedInstant);
+        long days = minutes / (60 * 24);
+        long hours = (minutes % (60 * 24)) / 60;
+        long mins = minutes % 60;
+        StringBuilder sb = new StringBuilder();
+        if (days > 0) {
+            sb.append(days).append("일 ");
+        }
+        if (hours > 0) {
+            sb.append(hours).append("시간 ");
+        }
+        if (mins > 0 || sb.length() == 0) {
+            sb.append(mins).append("분");
+        }
+        return sb.toString().trim();
+    }
+
+    /** 제시간·조기면 {@code null}, 지각이면 마감 후 경과(분) */
+    public static Integer minutesLateIfLate(LocalDateTime submittedAt, LocalDateTime dueAt) {
+        if (submittedAt == null || dueAt == null) {
+            return null;
+        }
+        Instant submittedInstant = submittedAt.atZone(KST_ZONE).toInstant();
+        Instant dueInstant = dueAt.atZone(UTC_ZONE).toInstant();
+        if (!submittedInstant.isAfter(dueInstant)) {
+            return null;
+        }
+        return (int) ChronoUnit.MINUTES.between(dueInstant, submittedInstant);
+    }
+}

--- a/src/main/java/com/project/handongjudge/grade/controller/GradeController.java
+++ b/src/main/java/com/project/handongjudge/grade/controller/GradeController.java
@@ -5,6 +5,8 @@ import com.project.handongjudge.assignment.entity.Assignment;
 import com.project.handongjudge.assignment.repository.AssignmentRepository;
 import com.project.handongjudge.assignment.service.AssignmentService;
 import com.project.handongjudge.grade.dto.*;
+import com.project.handongjudge.common.ZipExportPathUtils;
+import com.project.handongjudge.common.time.SubmissionDeadlineComparison;
 import com.project.handongjudge.grade.service.GradeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -15,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -81,7 +82,8 @@ public class GradeController {
     }
 
     /**
-     * 과제 제출 코드 ZIP 다운로드 (메타 CSV + 코드 파일)
+     * 과제 제출 코드 ZIP 다운로드 (메타 CSV + 코드 파일).
+     * 경로: {과제명}/{문제}/{학번_이름}/코드파일
      */
     @GetMapping("/export-zip")
     public ResponseEntity<byte[]> exportAssignmentCodesZip(
@@ -112,11 +114,11 @@ public class GradeController {
                     }
 
                     String safeAssignment = sanitize(assignment.getTitle());
-                    String safeStudent = sanitize(student.getStudentId());
+                    String safeStudent = ZipExportPathUtils.studentFolderSegment(student);
                     String safeProblem = sanitize(pg.getProblemTitle());
                     String ext = languageToExt(codeResponse.getLanguage());
                     String problemFolder = pg.getProblemId() + "_" + safeProblem;
-                    String baseCodePath = safeAssignment + "/" + problemFolder + "/" + safeStudent + "/" + safeProblem + "_" + fileTime(pg.getSubmittedAt());
+                    String baseCodePath = safeAssignment + "/" + problemFolder + "/" + safeStudent + "/" + safeProblem + "_" + SubmissionDeadlineComparison.submittedAtKstForZipPath(pg.getSubmittedAt());
                     String codePath = uniquePath(
                             baseCodePath,
                             ext,
@@ -139,10 +141,10 @@ public class GradeController {
                             .append(csvEsc(pg.getProblemTitle())).append(',')
                             .append(csvEsc(withSubmittedAt(pg.getProblemTitle(), pg.getSubmittedAt()))).append(',')
                             .append(csvEsc(pg.getResult())).append(',')
-                            .append(csvEsc(toStr(pg.getSubmittedAt()))).append(',')
-                            .append(csvEsc(toStr(assignment.getEndDate()))).append(',')
+                            .append(csvEsc(SubmissionDeadlineComparison.formatSubmittedAtKstCsv(pg.getSubmittedAt()))).append(',')
+                            .append(csvEsc(SubmissionDeadlineComparison.formatDueKstCsv(assignment.getEndDate()))).append(',')
                             .append(Boolean.TRUE.equals(pg.getIsOnTime()) ? "true" : "false").append(',')
-                            .append(csvEsc(toLateText(pg.getSubmittedAt(), assignment.getEndDate()))).append(',')
+                            .append(csvEsc(SubmissionDeadlineComparison.lateDurationText(pg.getSubmittedAt(), assignment.getEndDate()))).append(',')
                             .append(csvEsc(codePath))
                             .append('\n');
                 }
@@ -247,35 +249,11 @@ public class GradeController {
         return value.replaceAll("[^a-zA-Z0-9가-힣._-]", "_");
     }
 
-    private static String toStr(LocalDateTime dt) {
-        return dt == null ? "" : dt.toString();
-    }
-
-    private static String toLateText(LocalDateTime submittedAt, LocalDateTime dueAt) {
-        if (submittedAt == null || dueAt == null) return "";
-        Duration d = Duration.between(dueAt, submittedAt);
-        if (d.isNegative() || d.isZero()) return "";
-        long minutes = d.toMinutes();
-        long days = minutes / (60 * 24);
-        long hours = (minutes % (60 * 24)) / 60;
-        long mins = minutes % 60;
-        StringBuilder sb = new StringBuilder();
-        if (days > 0) sb.append(days).append("일 ");
-        if (hours > 0) sb.append(hours).append("시간 ");
-        if (mins > 0 || sb.length() == 0) sb.append(mins).append("분");
-        return sb.toString().trim();
-    }
-
     private static String withSubmittedAt(String base, LocalDateTime submittedAt) {
         String value = base == null ? "" : base;
-        String submitted = toStr(submittedAt);
+        String submitted = SubmissionDeadlineComparison.formatSubmittedAtKstCsv(submittedAt);
         if (submitted.isEmpty()) return value;
         return value + " (" + submitted + ")";
-    }
-
-    private static String fileTime(LocalDateTime dt) {
-        if (dt == null) return "unknown_time";
-        return dt.toString().replace(":", "-").replace(".", "-");
     }
 
     private static String languageToExt(String language) {

--- a/src/main/java/com/project/handongjudge/grade/service/GradeServiceImpl.java
+++ b/src/main/java/com/project/handongjudge/grade/service/GradeServiceImpl.java
@@ -12,6 +12,7 @@ import com.project.handongjudge.section.entity.Section;
 import com.project.handongjudge.section.service.SectionRoleService;
 import com.project.handongjudge.submission.entity.Submission;
 import com.project.handongjudge.submission.repository.SubmissionRepository;
+import com.project.handongjudge.common.time.SubmissionDeadlineComparison;
 import com.project.handongjudge.submission.service.SubmissionService;
 import com.project.handongjudge.user.entity.User;
 import com.project.handongjudge.user.repository.EnrollmentRepository;
@@ -21,8 +22,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.time.Instant;
-import java.time.ZoneId;
 import java.util.*;
 
 import org.springframework.data.domain.PageRequest;
@@ -31,21 +30,6 @@ import org.springframework.data.domain.PageRequest;
 @Service
 @RequiredArgsConstructor
 public class GradeServiceImpl implements GradeService {
-    private static final ZoneId KST_ZONE = ZoneId.of("Asia/Seoul");
-    private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
-
-    /**
-     * 지각 여부 판정 헬퍼.
-     * submittedAt은 서버 JVM 시스템 타임존(LocalDateTime.now()) 기준,
-     * dueAt은 프론트 toISOString()→UTC 문자열이 그대로 저장된 UTC 기준 LocalDateTime이므로
-     * 각각 올바른 ZoneId로 Instant 변환 후 비교한다.
-     */
-    private static boolean isSubmittedOnTime(LocalDateTime submittedAt, LocalDateTime dueAt) {
-        if (submittedAt == null || dueAt == null) return true;
-        Instant submittedInstant = submittedAt.atZone(KST_ZONE).toInstant();
-        Instant dueInstant = dueAt.atZone(UTC_ZONE).toInstant();
-        return !submittedInstant.isAfter(dueInstant);
-    }
 
     private final GradeRepository gradeRepository;
     private final AssignmentRepository assignmentRepository;
@@ -183,7 +167,7 @@ public class GradeServiceImpl implements GradeService {
                     pg.setSubmitted(true);
                     pg.setSubmittedAt(sub.getSubmittedAt());
                     if (assignment.getEndDate() != null) {
-                        pg.setIsOnTime(isSubmittedOnTime(sub.getSubmittedAt(), assignment.getEndDate()));
+                        pg.setIsOnTime(SubmissionDeadlineComparison.isSubmittedOnTime(sub.getSubmittedAt(), assignment.getEndDate()));
                     } else {
                         pg.setIsOnTime(true);
                     }
@@ -253,7 +237,7 @@ public class GradeServiceImpl implements GradeService {
                 pg.setSubmitted(true);
                 pg.setSubmittedAt(sub.getSubmittedAt());
                 if (assignment.getEndDate() != null) {
-                        pg.setIsOnTime(isSubmittedOnTime(sub.getSubmittedAt(), assignment.getEndDate()));
+                        pg.setIsOnTime(SubmissionDeadlineComparison.isSubmittedOnTime(sub.getSubmittedAt(), assignment.getEndDate()));
                 } else {
                     pg.setIsOnTime(true);
                 }
@@ -357,7 +341,7 @@ public class GradeServiceImpl implements GradeService {
                     .result(submission.getResult());
 
             if (assignment.getEndDate() != null) {
-                builder.isOnTime(isSubmittedOnTime(submission.getSubmittedAt(), assignment.getEndDate()));
+                builder.isOnTime(SubmissionDeadlineComparison.isSubmittedOnTime(submission.getSubmittedAt(), assignment.getEndDate()));
             } else {
                 builder.isOnTime(true);
             }

--- a/src/main/java/com/project/handongjudge/quiz/controller/QuizController.java
+++ b/src/main/java/com/project/handongjudge/quiz/controller/QuizController.java
@@ -8,6 +8,8 @@ import com.project.handongjudge.assignment.dto.StudentProgressResponse;
 import com.project.handongjudge.quiz.dto.*;
 import com.project.handongjudge.quiz.entity.Quiz;
 import com.project.handongjudge.quiz.service.QuizService;
+import com.project.handongjudge.common.ZipExportPathUtils;
+import com.project.handongjudge.common.time.SubmissionDeadlineComparison;
 import com.project.handongjudge.quiz.service.QuizSessionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -20,7 +22,6 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -246,11 +247,11 @@ public class QuizController {
                     }
 
                     String safeQuiz = sanitize(quiz.getTitle());
-                    String safeStudent = sanitize(student.getStudentId());
+                    String safeStudent = ZipExportPathUtils.studentFolderSegment(student);
                     String safeProblem = sanitize(pg.getProblemTitle());
                     String ext = languageToExt(codeResponse.getLanguage());
                     String problemFolder = pg.getProblemId() + "_" + safeProblem;
-                    String baseCodePath = safeQuiz + "/" + problemFolder + "/" + safeStudent + "/" + safeProblem + "_" + fileTime(pg.getSubmittedAt());
+                    String baseCodePath = safeQuiz + "/" + problemFolder + "/" + safeStudent + "/" + safeProblem + "_" + SubmissionDeadlineComparison.submittedAtKstForZipPath(pg.getSubmittedAt());
                     String codePath = uniquePath(
                             baseCodePath,
                             ext,
@@ -273,10 +274,10 @@ public class QuizController {
                             .append(csvEsc(pg.getProblemTitle())).append(',')
                             .append(csvEsc(withSubmittedAt(pg.getProblemTitle(), pg.getSubmittedAt()))).append(',')
                             .append(csvEsc(pg.getResult())).append(',')
-                            .append(csvEsc(toStr(pg.getSubmittedAt()))).append(',')
-                            .append(csvEsc(toStr(quiz.getEndTime()))).append(',')
+                            .append(csvEsc(SubmissionDeadlineComparison.formatSubmittedAtKstCsv(pg.getSubmittedAt()))).append(',')
+                            .append(csvEsc(SubmissionDeadlineComparison.formatDueKstCsv(quiz.getEndTime()))).append(',')
                             .append(Boolean.TRUE.equals(pg.getIsOnTime()) ? "true" : "false").append(',')
-                            .append(csvEsc(toLateText(pg.getSubmittedAt(), quiz.getEndTime()))).append(',')
+                            .append(csvEsc(SubmissionDeadlineComparison.lateDurationText(pg.getSubmittedAt(), quiz.getEndTime()))).append(',')
                             .append(csvEsc(codePath))
                             .append('\n');
                 }
@@ -299,7 +300,7 @@ public class QuizController {
 
     /**
      * 섹션의 전체 코딩테스트 제출 코드 ZIP 다운로드
-     * 구조: 전체코딩테스트/{코딩테스트명}/{문제}/{학번}/코드파일
+     * 구조: 전체코딩테스트/{코딩테스트명}/{문제}/{학번_이름}/코드파일
      */
     @GetMapping("/grades/export-zip-all")
     public ResponseEntity<byte[]> exportAllQuizCodesZip(
@@ -330,11 +331,11 @@ public class QuizController {
                         }
 
                         String safeQuiz = sanitize(quiz.getTitle());
-                        String safeStudent = sanitize(student.getStudentId());
+                        String safeStudent = ZipExportPathUtils.studentFolderSegment(student);
                         String safeProblem = sanitize(pg.getProblemTitle());
                         String ext = languageToExt(codeResponse.getLanguage());
                         String problemFolder = pg.getProblemId() + "_" + safeProblem;
-                        String baseCodePath = "전체코딩테스트/" + safeQuiz + "/" + problemFolder + "/" + safeStudent + "/" + safeProblem + "_" + fileTime(pg.getSubmittedAt());
+                        String baseCodePath = "전체코딩테스트/" + safeQuiz + "/" + problemFolder + "/" + safeStudent + "/" + safeProblem + "_" + SubmissionDeadlineComparison.submittedAtKstForZipPath(pg.getSubmittedAt());
                         String codePath = uniquePath(
                                 baseCodePath,
                                 ext,
@@ -358,10 +359,10 @@ public class QuizController {
                                 .append(csvEsc(pg.getProblemTitle())).append(',')
                                 .append(csvEsc(withSubmittedAt(pg.getProblemTitle(), pg.getSubmittedAt()))).append(',')
                                 .append(csvEsc(pg.getResult())).append(',')
-                                .append(csvEsc(toStr(pg.getSubmittedAt()))).append(',')
-                                .append(csvEsc(toStr(quiz.getEndTime()))).append(',')
+                                .append(csvEsc(SubmissionDeadlineComparison.formatSubmittedAtKstCsv(pg.getSubmittedAt()))).append(',')
+                                .append(csvEsc(SubmissionDeadlineComparison.formatDueKstCsv(quiz.getEndTime()))).append(',')
                                 .append(Boolean.TRUE.equals(pg.getIsOnTime()) ? "true" : "false").append(',')
-                                .append(csvEsc(toLateText(pg.getSubmittedAt(), quiz.getEndTime()))).append(',')
+                                .append(csvEsc(SubmissionDeadlineComparison.lateDurationText(pg.getSubmittedAt(), quiz.getEndTime()))).append(',')
                                 .append(csvEsc(codePath))
                                 .append('\n');
                     }
@@ -623,35 +624,11 @@ public class QuizController {
         return value.replaceAll("[^a-zA-Z0-9가-힣._-]", "_");
     }
 
-    private static String toStr(LocalDateTime dt) {
-        return dt == null ? "" : dt.toString();
-    }
-
-    private static String toLateText(LocalDateTime submittedAt, LocalDateTime dueAt) {
-        if (submittedAt == null || dueAt == null) return "";
-        Duration d = Duration.between(dueAt, submittedAt);
-        if (d.isNegative() || d.isZero()) return "";
-        long minutes = d.toMinutes();
-        long days = minutes / (60 * 24);
-        long hours = (minutes % (60 * 24)) / 60;
-        long mins = minutes % 60;
-        StringBuilder sb = new StringBuilder();
-        if (days > 0) sb.append(days).append("일 ");
-        if (hours > 0) sb.append(hours).append("시간 ");
-        if (mins > 0 || sb.length() == 0) sb.append(mins).append("분");
-        return sb.toString().trim();
-    }
-
     private static String withSubmittedAt(String base, LocalDateTime submittedAt) {
         String value = base == null ? "" : base;
-        String submitted = toStr(submittedAt);
+        String submitted = SubmissionDeadlineComparison.formatSubmittedAtKstCsv(submittedAt);
         if (submitted.isEmpty()) return value;
         return value + " (" + submitted + ")";
-    }
-
-    private static String fileTime(LocalDateTime dt) {
-        if (dt == null) return "unknown_time";
-        return dt.toString().replace(":", "-").replace(".", "-");
     }
 
     private static String languageToExt(String language) {

--- a/src/main/java/com/project/handongjudge/quiz/service/QuizService.java
+++ b/src/main/java/com/project/handongjudge/quiz/service/QuizService.java
@@ -23,6 +23,7 @@ import com.project.handongjudge.progress.repository.CodeProgressRepository;
 import com.project.handongjudge.submission.entity.Submission;
 import com.project.handongjudge.submission.repository.SubmissionRepository;
 import com.project.handongjudge.submission.service.SubmissionService;
+import com.project.handongjudge.common.time.SubmissionDeadlineComparison;
 import com.project.handongjudge.section.service.SectionRoleService;
 import com.project.handongjudge.mypage.dto.SubmissionCodeDto;
 import lombok.RequiredArgsConstructor;
@@ -592,10 +593,8 @@ public class QuizService {
                     pg.setPassedTestCases(sub.getPassedTestCases());
                     pg.setTotalTestCases(sub.getTotalTestCases());
                     if (quiz.getEndTime() != null) {
-                        pg.setIsOnTime(
-                                sub.getSubmittedAt().isBefore(quiz.getEndTime()) ||
-                                sub.getSubmittedAt().isEqual(quiz.getEndTime())
-                        );
+                        pg.setIsOnTime(SubmissionDeadlineComparison.isSubmittedOnTime(
+                                sub.getSubmittedAt(), quiz.getEndTime()));
                     } else {
                         pg.setIsOnTime(true);
                     }
@@ -774,10 +773,8 @@ public class QuizService {
                     .submittedAt(submission.getSubmittedAt())
                     .result(submission.getResult());
             if (quiz.getEndTime() != null) {
-                b.isOnTime(
-                        submission.getSubmittedAt().isBefore(quiz.getEndTime()) ||
-                        submission.getSubmittedAt().isEqual(quiz.getEndTime())
-                );
+                b.isOnTime(SubmissionDeadlineComparison.isSubmittedOnTime(
+                        submission.getSubmittedAt(), quiz.getEndTime()));
             } else {
                 b.isOnTime(true);
             }

--- a/src/main/java/com/project/handongjudge/submission/service/SubmissionService.java
+++ b/src/main/java/com/project/handongjudge/submission/service/SubmissionService.java
@@ -946,6 +946,7 @@ public class SubmissionService {
      * 비고:
      * - 관리자/튜터는 비활성화된 과제/퀴즈도 제출 가능
      * - 학생은 마감일이 지나면 제출 불가
+     * - 학생은 퀴즈 상태가 PAUSED·ENDED이거나 종료 시각이 지나면 제출 불가
      * - 관리자/튜터는 퀴즈 종료 후에도 제출 가능 (과제는 마감일 체크)
      */
     private void validateSubmission(Long problemId, Long sectionId, Long userId) {
@@ -1012,6 +1013,10 @@ public class SubmissionService {
                             continue;
                         }
 
+                        if (quiz.getStatus() == Quiz.QuizStatus.ENDED) {
+                            continue;
+                        }
+
                         if (quiz.getEndTime() == null || !now.isAfter(quiz.getEndTime())) {
                             quizValid = true;
                             hasRunningOrWaitingQuiz = true;
@@ -1025,6 +1030,10 @@ public class SubmissionService {
                         }
                         if (!hasRunningOrWaitingQuiz && quizzesInSection.stream().anyMatch(q -> q.getStatus() == Quiz.QuizStatus.PAUSED)) {
                             throw new IllegalArgumentException("코딩 테스트가 일시정지 상태입니다. 진행이 재개될 때까지 제출할 수 없습니다");
+                        }
+                        if (!hasRunningOrWaitingQuiz && quizzesInSection.stream().anyMatch(q ->
+                                Boolean.TRUE.equals(q.getActive()) && q.getStatus() == Quiz.QuizStatus.ENDED)) {
+                            throw new IllegalArgumentException("코딩 테스트가 종료되어 제출할 수 없습니다");
                         }
                         throw new IllegalArgumentException("코딩 테스트 시간이 종료되었습니다");
                     }

--- a/src/main/java/com/project/handongjudge/user/service/UserService.java
+++ b/src/main/java/com/project/handongjudge/user/service/UserService.java
@@ -29,13 +29,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.project.handongjudge.common.time.SubmissionDeadlineComparison;
 import com.project.handongjudge.community.service.NotificationService;
 import com.project.handongjudge.domjudge.service.DomjudgeService;
 import java.util.ArrayList;
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.time.Instant;
-import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,15 +45,6 @@ import java.util.stream.Collectors;
 @Slf4j
 @Transactional(readOnly = true)
 public class UserService {
-    /**
-     * endDate는 프론트에서 toISOString()으로 UTC 문자열을 보내고,
-     * @JsonFormat(timezone="UTC")에 의해 UTC 숫자 그대로 LocalDateTime에 저장된다.
-     * submittedAt은 LocalDateTime.now()로 JVM 시스템 타임존(서버 OS) 기준으로 저장된다.
-     * 두 값의 암묵적 타임존이 달라 직접 비교하면 시차만큼 오판정이 발생하므로,
-     * 각각의 기준 존으로 Instant 변환 후 비교한다.
-     */
-    private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
-
 
     private final UserRepository userRepository;
     private final EnrollmentRepository enrollmentRepository;
@@ -567,14 +556,8 @@ public class UserService {
                 submittedAt = latest.getSubmittedAt();
                 status = "AC".equals(latest.getResult()) ? "ACCEPTED" : "SUBMITTED";
                 if (endDate != null) {
-                    // submittedAt은 저장 시 Asia/Seoul(LocalDateTime.now(KST)) 기준으로 생성됨
-                    // endDate는 프론트 toISOString()→UTC 문자열이 @JsonFormat(timezone="UTC")로 저장 → UTC로 해석
-                    Instant submittedInstant = submittedAt.atZone(ZoneId.of("Asia/Seoul")).toInstant();
-                    Instant dueInstant = endDate.atZone(UTC_ZONE).toInstant();
-                    isOnTime = !submittedInstant.isAfter(dueInstant);
-                    if (submittedInstant.isAfter(dueInstant)) {
-                        minutesLate = (int) ChronoUnit.MINUTES.between(dueInstant, submittedInstant);
-                    }
+                    isOnTime = SubmissionDeadlineComparison.isSubmittedOnTime(submittedAt, endDate);
+                    minutesLate = SubmissionDeadlineComparison.minutesLateIfLate(submittedAt, endDate);
                 } else {
                     isOnTime = true;
                 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,8 @@ server:
 
 spring:
   #.env import
-  # config:
-  #  import: "optional:file:.env[.properties]"
+  config:
+    import: "optional:file:.env[.properties]"
 
   redis:
     host: ${REDIS_HOST:127.0.0.1}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #184 

## 📝작업 내용

# [BE] 코딩테스트 제출 검증 · 제출 코드 ZIP 경로 개선

## 배경 / 목적
- 튜터가 코딩테스트를 조기 종료(`ENDED`)한 경우에도 학생이 제출할 수 있던 동작을 막고, 서버에서 일관되게 검증한다.
- 튜터가 내려받는 제출 코드 ZIP에서 학생 폴더를 `학번`만이 아니라 `학번_이름`으로 식별하기 쉽게 한다.

---

## 1. 학생 코딩테스트 제출 차단 (`ENDED` 포함)

### 문제
- 활성 코딩테스트가 `PAUSED`이거나 종료 시각이 지난 경우만 막혀 있었다면, **`ENDED` 상태**에서도 학생 제출이 가능한 경우가 있었다.
- 예약 종료 전 튜터가 조기 종료한 뒤에도 제출이 열려 있으면 정책과 맞지 않음.

### 해결 방향
- `SubmissionService.validateSubmission`에서 학생(비 매니저) 기준으로, 해당 문제가 속한 **활성 퀴즈**를 순회할 때:
  - `PAUSED` → 진행 중으로 보지 않음 (기존과 동일한 취지).
  - **`ENDED` → 진행 중으로 보지 않음** (신규/명시).
  - 종료 시각 경과도 기존과 같이 제출 불가.
- 예외 메시지 분기:
  - 일시정지 → 기존 메시지 유지.
  - **`ENDED`인 활성 퀴즈가 있으면** → `"코딩 테스트가 종료되어 제출할 수 없습니다"`.
  - 그 외 시간 종료 → `"코딩 테스트 시간이 종료되었습니다"` 등.

### 관련 코드
- `Handongjudge_BE/src/main/java/com/project/handongjudge/submission/service/SubmissionService.java`
  - 메서드: `validateSubmission`
  - Javadoc에 `PAUSED`·`ENDED`·종료 시각 조건 명시.

### 수동 테스트 시나리오
1. 코딩테스트를 `ACTIVE`로 두고 학생 제출 → 성공.
2. 튜터가 상태를 `ENDED`로 변경 후 동일 문제 제출 → **400 등으로 거부**, 메시지에 “종료” 안내.
3. `PAUSED` 상태에서 제출 → 거부, “일시정지” 안내.
4. 튜터/관리자는 (기존 정책대로) 필요 시 제출 가능 여부 확인.

---

## 2. 제출 코드 ZIP: 학생 폴더명 `학번_이름`

### 문제
- ZIP 내부 경로가 `{…}/{문제}/{학번}/코드파일` 형태라 동명이인·학번만으로는 식별이 불편할 수 있음.

### 해결 방향
- 공통 유틸 `ZipExportPathUtils` 추가:
  - `studentFolderSegment(StudentGradeSummaryDTO)` (또는 id/name 오버로드)
  - 규칙: **`학번_이름`**으로 조합 후, 경로에 안전한 문자만 남기도록 정규화 (기존 `sanitize`와 동일한 문자 클래스).
  - 이름이 비어 있으면 **학번만**, 둘 다 없으면 `unknown`.

### 적용 엔드포인트
- 과제 성적 ZIP: `GradeController` — `GET …/grades/export-zip`
- 퀴즈 성적 ZIP: `QuizController` — `GET …/quizzes/{quizId}/grades/export-zip`
- 섹션 전체 퀴즈 ZIP: `QuizController` — `GET …/quizzes/grades/export-zip-all`  
  - 경로 주석: `전체코딩테스트/…/{학번_이름}/…`
- 섹션 전체 과제 ZIP: `AssignmentController` — `GET …/export-zip-all`  
  - 경로 주석: `전체과제/…/{학번_이름}/…`

### 관련 파일
- `Handongjudge_BE/src/main/java/com/project/handongjudge/common/ZipExportPathUtils.java` (신규)
- `GradeController.java`, `QuizController.java`, `AssignmentController.java`

### 수동 테스트
- 각 ZIP 다운로드 후 압축 해제 → 문제 폴더 아래 디렉터리명이 `학번_이름` 형태인지 확인.
- `studentName` 없는 계정/데이터 → 학번만 또는 `unknown` 동작 확인.

---

## 3. (참고) 성적·제출 메타데이터

### 제출 엔티티 / DTO
- `Submission`에 맞은/전체 테스트케이스 수 필드 및 저장·갱신 로직이 있다면, 성적 API(`StudentGradeSummaryDTO.ProblemGradeDTO`의 `passedTestCases`, `totalTestCases` 등)와 연동 여부를 이슈/PR 설명에 함께 적는 것이 좋음.

---

## 체크리스트
- [ ] `./gradlew compileJava` / 테스트 통과
- [ ] `ENDED` / `PAUSED` / 시간 만료 제출 시나리오 검증
- [ ] ZIP 4종 경로에 `학번_이름` 반영 확인