### PR TITLE
fix/issue-193/커뮤니티수정사항

### DIFF
--- a/src/main/java/com/project/handongjudge/community/controller/CommentController.java
+++ b/src/main/java/com/project/handongjudge/community/controller/CommentController.java
@@ -92,40 +92,6 @@ public class CommentController {
 
         return ResponseEntity.ok(result);
     }
-
-    @PostMapping("/{commentId}/accept")
-    @Operation(summary = "댓글 채택 (질문 작성자만)")
-    public ResponseEntity<Map<String, Object>> acceptComment(
-            @PathVariable Long commentId,
-            Authentication authentication) {
-        
-        Long userId = Long.parseLong(authentication.getName());
-        CommentResponseDto response = commentService.acceptComment(commentId, userId);
-
-        Map<String, Object> result = new HashMap<>();
-        result.put("success", true);
-        result.put("message", "댓글이 채택되었습니다");
-        result.put("data", response);
-
-        return ResponseEntity.ok(result);
-    }
-
-    @DeleteMapping("/{commentId}/accept")
-    @Operation(summary = "댓글 채택 해제")
-    public ResponseEntity<Map<String, Object>> unacceptComment(
-            @PathVariable Long commentId,
-            Authentication authentication) {
-        
-        Long userId = Long.parseLong(authentication.getName());
-        CommentResponseDto response = commentService.unacceptComment(commentId, userId);
-
-        Map<String, Object> result = new HashMap<>();
-        result.put("success", true);
-        result.put("message", "댓글 채택이 해제되었습니다");
-        result.put("data", response);
-
-        return ResponseEntity.ok(result);
-    }
 }
 
 

--- a/src/main/java/com/project/handongjudge/community/dto/CommentResponseDto.java
+++ b/src/main/java/com/project/handongjudge/community/dto/CommentResponseDto.java
@@ -26,12 +26,14 @@ public class CommentResponseDto {
     private Boolean isLikedByCurrentUser;  // 현재 사용자가 추천했는지
     private Boolean isAuthor;  // 현재 사용자가 작성자인지
 
+    /** 교수/TA만 수신: 실제 작성자 이름 */
+    private String authorRealNameForStaff;
+
     // Entity -> DTO 변환
     public static CommentResponseDto fromEntity(Comment comment) {
         return CommentResponseDto.builder()
                 .id(comment.getId())
                 .questionId(comment.getQuestion().getId())
-                .authorId(comment.getAuthor().getId())
                 .authorDisplayName(comment.getAuthorDisplayName())
                 .content(comment.getContent())
                 .isAnonymous(comment.getIsAnonymous())

--- a/src/main/java/com/project/handongjudge/community/dto/QuestionCreateDto.java
+++ b/src/main/java/com/project/handongjudge/community/dto/QuestionCreateDto.java
@@ -30,6 +30,11 @@ public class QuestionCreateDto {
     @NotNull(message = "익명 여부는 필수입니다")
     private Boolean isAnonymous;
 
+    /**
+     * 익명 질문일 때만 사용. true(기본): 섹션 별명으로 표시, false: 표시명 "익명" 고정
+     */
+    private Boolean anonymousUseNickname;
+
     @NotNull(message = "공개 여부는 필수입니다")
     private Boolean isPublic;
 }

--- a/src/main/java/com/project/handongjudge/community/dto/QuestionListDto.java
+++ b/src/main/java/com/project/handongjudge/community/dto/QuestionListDto.java
@@ -27,6 +27,15 @@ public class QuestionListDto {
     private Boolean hasAcceptedAnswer;
     private Boolean isPublic;
 
+    /** 현재 로그인 사용자가 작성자인지 */
+    private Boolean isAuthor;
+
+    /** 교수/TA에게만 내려가는 실제 작성자 이름 */
+    private String authorRealNameForStaff;
+
+    /** 교수/TA에게만 내려가는 작성자 user id */
+    private Long authorId;
+
     // Entity -> DTO 변환 (목록용 축약)
     public static QuestionListDto fromEntity(Question question) {
         return QuestionListDto.builder()

--- a/src/main/java/com/project/handongjudge/community/dto/QuestionResponseDto.java
+++ b/src/main/java/com/project/handongjudge/community/dto/QuestionResponseDto.java
@@ -24,6 +24,8 @@ public class QuestionResponseDto {
     private String title;
     private String content;
     private Boolean isAnonymous;
+    /** 익명 질문일 때 별명 표시 여부(null이면 레거시: 별명 사용으로 간주) */
+    private Boolean anonymousUseNickname;
     private Boolean isPublic;
     private Boolean isPinned;
     private String status;
@@ -34,6 +36,9 @@ public class QuestionResponseDto {
     private LocalDateTime updatedAt;
     private Boolean isLikedByCurrentUser;  // 현재 사용자가 추천했는지
     private Boolean isAuthor;  // 현재 사용자가 작성자인지
+
+    /** 교수/TA만 수신: 실제 작성자 이름 */
+    private String authorRealNameForStaff;
 
     // Entity -> DTO 변환
     public static QuestionResponseDto fromEntity(Question question) {
@@ -46,11 +51,11 @@ public class QuestionResponseDto {
                 .assignmentTitle(question.getAssignment() != null ? question.getAssignment().getTitle() : null)
                 .problemId(question.getProblem() != null ? question.getProblem().getId() : null)
                 .problemTitle(question.getProblem() != null ? question.getProblem().getTitle() : null)
-                .authorId(question.getAuthor().getId())
                 .authorDisplayName(question.getAuthorDisplayName())
                 .title(question.getTitle())
                 .content(question.getContent())
                 .isAnonymous(question.getIsAnonymous())
+                .anonymousUseNickname(question.getAnonymousUseNickname())
                 .isPublic(question.getIsPublic())
                 .isPinned(question.getIsPinned())
                 .status(question.getStatus().name())

--- a/src/main/java/com/project/handongjudge/community/entity/Question.java
+++ b/src/main/java/com/project/handongjudge/community/entity/Question.java
@@ -70,6 +70,10 @@ public class Question {
     @Builder.Default
     private Boolean isAnonymous = false;
 
+    // 익명 질문일 때 표시에 별명을 쓸지(true) / 문자 그대로 "익명"만 쓸지(false). 비익명이면 null
+    @Column(name = "anonymous_use_nickname")
+    private Boolean anonymousUseNickname;
+
     // 공개/비공개 (false: 공개, true: 비공개 - 교수만 볼 수 있음)
     @Column(name = "is_public", nullable = false)
     @Builder.Default

--- a/src/main/java/com/project/handongjudge/community/repository/CommentRepository.java
+++ b/src/main/java/com/project/handongjudge/community/repository/CommentRepository.java
@@ -27,10 +27,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 질문별 댓글 수
     Long countByQuestion(Question question);
 
-    // 질문별 채택된 댓글 조회
-    @Query("SELECT c FROM Comment c WHERE c.question = :question AND c.isAccepted = true")
-    List<Comment> findAcceptedCommentsByQuestion(@Param("question") Question question);
-
     // 교수/TA 답변 조회
     @Query("SELECT c FROM Comment c WHERE c.question = :question AND c.isInstructorAnswer = true ORDER BY c.createdAt ASC")
     List<Comment> findInstructorCommentsByQuestion(@Param("question") Question question);

--- a/src/main/java/com/project/handongjudge/community/repository/QuestionRepository.java
+++ b/src/main/java/com/project/handongjudge/community/repository/QuestionRepository.java
@@ -61,6 +61,9 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     // 핀된 질문 목록
     List<Question> findBySectionAndIsPinnedTrueOrderByCreatedAtDesc(Section section);
 
+    /** 같은 섹션·익명 질문에서 이미 쓰인 표시명인지 (랜덤 별칭 중복 방지) */
+    boolean existsBySectionAndIsAnonymousTrueAndAuthorDisplayName(Section section, String authorDisplayName);
+
     /** 과제 삭제 시 FK 제약 회피: 해당 과제를 참조하는 질문의 assignment를 null로 변경 (질문은 유지) */
     @Modifying
     @Query("UPDATE Question q SET q.assignment = null WHERE q.assignment.id = :assignmentId")

--- a/src/main/java/com/project/handongjudge/community/service/CommentService.java
+++ b/src/main/java/com/project/handongjudge/community/service/CommentService.java
@@ -6,11 +6,9 @@ import com.project.handongjudge.community.dto.CommentResponseDto;
 import com.project.handongjudge.community.dto.CommentUpdateDto;
 import com.project.handongjudge.community.entity.Comment;
 import com.project.handongjudge.community.entity.Question;
-import com.project.handongjudge.community.entity.UserNickname;
 import com.project.handongjudge.community.repository.CommentLikeRepository;
 import com.project.handongjudge.community.repository.CommentRepository;
 import com.project.handongjudge.community.repository.QuestionRepository;
-import com.project.handongjudge.community.repository.UserNicknameRepository;
 import com.project.handongjudge.section.entity.Section;
 import com.project.handongjudge.section.service.SectionRoleService;
 import com.project.handongjudge.user.entity.User;
@@ -19,8 +17,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,9 +31,23 @@ public class CommentService {
     private final QuestionRepository questionRepository;
     private final SectionRoleService sectionRoleService;
     private final UserRepository userRepository;
-    private final UserNicknameRepository userNicknameRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final NotificationService notificationService;
+
+    /**
+     * 질문 내 익명 댓글에 부여할 표시 순번 (작성 시각 오름차순 기준 1부터)
+     */
+    private static Map<Long, Integer> buildAnonymousDisplayOrder(List<Comment> commentsOrderedAsc) {
+        Map<Long, Integer> map = new HashMap<>();
+        int n = 0;
+        for (Comment c : commentsOrderedAsc) {
+            if (Boolean.TRUE.equals(c.getIsAnonymous())) {
+                n++;
+                map.put(c.getId(), n);
+            }
+        }
+        return map;
+    }
 
     /**
      * 댓글 생성
@@ -47,39 +60,38 @@ public class CommentService {
         Question question = questionRepository.findById(dto.getQuestionId())
                 .orElseThrow(() -> new CustomException("질문을 찾을 수 없습니다"));
 
-        // 작성자 표시명 설정
-        String displayName = getDisplayName(author, question.getSection(), dto.getIsAnonymous());
+        boolean anonymous = Boolean.TRUE.equals(dto.getIsAnonymous());
+        String displayName = anonymous ? "익명" : author.getName();
 
-        // 교수/TA 답변 여부 확인
-        boolean isInstructorAnswer = isInstructor(author, question.getSection());
+        // 익명이면 교수/TA 배지를 쓰지 않음(익명 의미가 깨짐)
+        boolean isInstructorAnswer = !anonymous && isInstructor(author, question.getSection());
 
-        // 댓글 엔티티 생성
         Comment comment = Comment.builder()
                 .question(question)
                 .author(author)
                 .content(sanitizeHtmlContent(dto.getContent()))
-                .isAnonymous(dto.getIsAnonymous())
+                .isAnonymous(anonymous)
                 .authorDisplayName(displayName)
                 .isInstructorAnswer(isInstructorAnswer)
                 .build();
 
         Comment savedComment = commentRepository.save(comment);
 
-        // 질문의 댓글 수 증가
         question.incrementCommentCount();
         questionRepository.save(question);
 
-        // 알림 발송 (질문 작성자에게, 본인이 아닌 경우)
         if (!question.getAuthor().getId().equals(userId)) {
             try {
                 notificationService.notifyQuestionComment(question, savedComment);
             } catch (Exception e) {
-                // 알림 발송 실패해도 댓글 작성은 성공 처리
                 System.err.println("알림 발송 실패: " + e.getMessage());
             }
         }
 
-        return convertToResponseDto(savedComment, userId);
+        List<Comment> all = commentRepository.findByQuestionOrderByCreatedAtAsc(question);
+        Map<Long, Integer> anonOrder = buildAnonymousDisplayOrder(all);
+        boolean viewerIsManager = isInstructor(author, question.getSection());
+        return toResponseDto(savedComment, userId, viewerIsManager, anonOrder.get(savedComment.getId()));
     }
 
     /**
@@ -89,10 +101,15 @@ public class CommentService {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new CustomException("질문을 찾을 수 없습니다"));
 
+        User viewer = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다"));
+
         List<Comment> comments = commentRepository.findByQuestionOrderByCreatedAtAsc(question);
+        Map<Long, Integer> anonOrder = buildAnonymousDisplayOrder(comments);
+        boolean manager = isInstructor(viewer, question.getSection());
 
         return comments.stream()
-                .map(comment -> convertToResponseDto(comment, userId))
+                .map(c -> toResponseDto(c, userId, manager, anonOrder.get(c.getId())))
                 .collect(Collectors.toList());
     }
 
@@ -107,16 +124,19 @@ public class CommentService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다"));
 
-        // 권한 검증: 작성자 또는 교수만 수정 가능
-        if (!comment.getAuthor().getId().equals(userId) && 
-            !isInstructor(user, comment.getQuestion().getSection())) {
+        if (!comment.getAuthor().getId().equals(userId) &&
+                !isInstructor(user, comment.getQuestion().getSection())) {
             throw new CustomException("이 댓글을 수정할 권한이 없습니다");
         }
 
         comment.setContent(sanitizeHtmlContent(dto.getContent()));
         Comment updatedComment = commentRepository.save(comment);
 
-        return convertToResponseDto(updatedComment, userId);
+        Question question = comment.getQuestion();
+        List<Comment> all = commentRepository.findByQuestionOrderByCreatedAtAsc(question);
+        Map<Long, Integer> anonOrder = buildAnonymousDisplayOrder(all);
+        boolean manager = isInstructor(user, question.getSection());
+        return toResponseDto(updatedComment, userId, manager, anonOrder.get(updatedComment.getId()));
     }
 
     /**
@@ -130,13 +150,11 @@ public class CommentService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다"));
 
-        // 권한 검증: 작성자 또는 교수만 삭제 가능
-        if (!comment.getAuthor().getId().equals(userId) && 
-            !isInstructor(user, comment.getQuestion().getSection())) {
+        if (!comment.getAuthor().getId().equals(userId) &&
+                !isInstructor(user, comment.getQuestion().getSection())) {
             throw new CustomException("이 댓글을 삭제할 권한이 없습니다");
         }
 
-        // 질문의 댓글 수 감소
         Question question = comment.getQuestion();
         question.decrementCommentCount();
         questionRepository.save(question);
@@ -144,106 +162,35 @@ public class CommentService {
         commentRepository.delete(comment);
     }
 
-    /**
-     * 댓글 채택 (질문 작성자만 가능)
-     */
-    @Transactional
-    public CommentResponseDto acceptComment(Long commentId, Long userId) {
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new CustomException("댓글을 찾을 수 없습니다"));
-
-        Question question = comment.getQuestion();
-
-        // 권한 검증: 질문 작성자만 채택 가능
-        if (!question.getAuthor().getId().equals(userId)) {
-            throw new CustomException("댓글을 채택할 권한이 없습니다");
-        }
-
-        // 기존 채택 댓글이 있다면 채택 해제
-        List<Comment> acceptedComments = commentRepository.findAcceptedCommentsByQuestion(question);
-        for (Comment acceptedComment : acceptedComments) {
-            acceptedComment.unaccept();
-            commentRepository.save(acceptedComment);
-        }
-
-        // 새로운 댓글 채택
-        comment.accept();
-        Comment updatedComment = commentRepository.save(comment);
-
-        // 질문 해결 상태로 변경
-        question.resolve();
-        questionRepository.save(question);
-
-        // 알림 발송 (댓글 작성자에게)
-        if (!comment.getAuthor().getId().equals(userId)) {
-            notificationService.notifyCommentAccepted(comment);
-        }
-
-        return convertToResponseDto(updatedComment, userId);
-    }
-
-    /**
-     * 댓글 채택 해제
-     */
-    @Transactional
-    public CommentResponseDto unacceptComment(Long commentId, Long userId) {
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new CustomException("댓글을 찾을 수 없습니다"));
-
-        Question question = comment.getQuestion();
-
-        // 권한 검증: 질문 작성자만 채택 해제 가능
-        if (!question.getAuthor().getId().equals(userId)) {
-            throw new CustomException("댓글 채택을 해제할 권한이 없습니다");
-        }
-
-        comment.unaccept();
-        Comment updatedComment = commentRepository.save(comment);
-
-        // 질문을 미해결 상태로 변경
-        question.reopen();
-        questionRepository.save(question);
-
-        return convertToResponseDto(updatedComment, userId);
-    }
-
-    // ========== Helper Methods ==========
-
-    private String getDisplayName(User user, Section section, Boolean isAnonymous) {
-        if (isAnonymous) {
-            Optional<UserNickname> nicknameOpt = userNicknameRepository.findByUserAndSection(user, section);
-            if (nicknameOpt.isPresent()) {
-                return nicknameOpt.get().getNickname();
-            } else {
-                String defaultNickname = "익명" + user.getId();
-                UserNickname nickname = UserNickname.builder()
-                        .user(user)
-                        .section(section)
-                        .nickname(defaultNickname)
-                        .build();
-                userNicknameRepository.save(nickname);
-                return defaultNickname;
-            }
-        } else {
-            return user.getName();
-        }
-    }
-
     private boolean isInstructor(User user, Section section) {
         return sectionRoleService.isManager(user.getId(), section.getId());
     }
 
     private String sanitizeHtmlContent(String content) {
-        // TODO: HTML sanitization 구현
         return content;
     }
 
-    private CommentResponseDto convertToResponseDto(Comment comment, Long currentUserId) {
+    private CommentResponseDto toResponseDto(Comment comment, Long currentUserId,
+                                               boolean viewerIsManager, Integer anonymousDisplayIndex) {
         CommentResponseDto dto = CommentResponseDto.fromEntity(comment);
+        if (Boolean.TRUE.equals(comment.getIsAnonymous())) {
+            dto.setIsInstructorAnswer(false);
+        }
+        if (Boolean.TRUE.equals(comment.getIsAnonymous()) && anonymousDisplayIndex != null) {
+            dto.setAuthorDisplayName("익명 " + anonymousDisplayIndex);
+        }
+        if (Boolean.TRUE.equals(comment.getIsAnonymous()) && !viewerIsManager) {
+            dto.setAuthorId(null);
+        } else {
+            dto.setAuthorId(comment.getAuthor().getId());
+        }
+        if (viewerIsManager) {
+            dto.setAuthorRealNameForStaff(comment.getAuthor().getName());
+        }
+        dto.setIsAccepted(false);
         dto.setIsLikedByCurrentUser(
                 commentLikeRepository.existsByCommentIdAndUserId(comment.getId(), currentUserId));
         dto.setIsAuthor(comment.getAuthor().getId().equals(currentUserId));
         return dto;
     }
 }
-

--- a/src/main/java/com/project/handongjudge/community/service/QuestionService.java
+++ b/src/main/java/com/project/handongjudge/community/service/QuestionService.java
@@ -5,10 +5,10 @@ import com.project.handongjudge.assignment.repository.AssignmentRepository;
 import com.project.handongjudge.common.exception.CustomException;
 import com.project.handongjudge.community.dto.*;
 import com.project.handongjudge.community.entity.Question;
-import com.project.handongjudge.community.entity.UserNickname;
 import com.project.handongjudge.community.repository.QuestionLikeRepository;
 import com.project.handongjudge.community.repository.QuestionRepository;
 import com.project.handongjudge.community.repository.UserNicknameRepository;
+import com.project.handongjudge.community.util.CommunityDisplayNameGenerator;
 import com.project.handongjudge.problem.entity.Problem;
 import com.project.handongjudge.problem.repository.ProblemRepository;
 import com.project.handongjudge.section.entity.Section;
@@ -24,7 +24,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -53,8 +52,9 @@ public class QuestionService {
         Section section = sectionRepository.findById(dto.getSectionId())
                 .orElseThrow(() -> new CustomException("섹션을 찾을 수 없습니다"));
 
+        Boolean useNicknameWhenAnonymous = resolveAnonymousUseNickname(dto);
         // 작성자 표시명 설정
-        String displayName = getDisplayName(author, section, dto.getIsAnonymous());
+        String displayName = getDisplayName(author, section, dto.getIsAnonymous(), useNicknameWhenAnonymous);
 
         // 질문 엔티티 생성
         Question.QuestionBuilder questionBuilder = Question.builder()
@@ -63,6 +63,7 @@ public class QuestionService {
                 .title(dto.getTitle())
                 .content(sanitizeHtmlContent(dto.getContent()))
                 .isAnonymous(dto.getIsAnonymous())
+                .anonymousUseNickname(dto.getIsAnonymous() ? useNicknameWhenAnonymous : null)
                 .isPublic(dto.getIsPublic())
                 .authorDisplayName(displayName);
 
@@ -109,14 +110,14 @@ public class QuestionService {
         }
 
         // 비공개 질문 필터링 (교수가 아닌 경우)
-        Page<QuestionListDto> result = questions.map(QuestionListDto::fromEntity);
+        Page<QuestionListDto> result = questions.map(q -> toQuestionListDto(q, user, section));
         
         if (!isInstructor(user, section)) {
             // 비공개 질문 필터링: 작성자 본인 또는 교수만 볼 수 있음
             List<QuestionListDto> filteredContent = result.getContent().stream()
                     .filter(q -> {
                         // 공개 글이거나, 작성자 본인인 경우만 표시
-                        if (q.getIsPublic()) return true;
+                        if (Boolean.TRUE.equals(q.getIsPublic())) return true;
                         // 비공개 글은 작성자만 볼 수 있음
                         Question originalQuestion = questionRepository.findById(q.getId()).orElse(null);
                         return originalQuestion != null && originalQuestion.getAuthor().getId().equals(userId);
@@ -270,14 +271,14 @@ public class QuestionService {
         Page<Question> questions = questionRepository.searchByKeyword(section, keyword, pageable);
 
         // 비공개 질문 필터링
-        Page<QuestionListDto> result = questions.map(QuestionListDto::fromEntity);
+        Page<QuestionListDto> result = questions.map(q -> toQuestionListDto(q, user, section));
 
         if (!isInstructor(user, section)) {
             // 비공개 질문 필터링: 작성자 본인 또는 교수만 볼 수 있음
             List<QuestionListDto> filteredContent = result.getContent().stream()
                     .filter(q -> {
                         // 공개 글이거나, 작성자 본인인 경우만 표시
-                        if (q.getIsPublic()) return true;
+                        if (Boolean.TRUE.equals(q.getIsPublic())) return true;
                         // 비공개 글은 작성자만 볼 수 있음
                         Question originalQuestion = questionRepository.findById(q.getId()).orElse(null);
                         return originalQuestion != null && originalQuestion.getAuthor().getId().equals(userId);
@@ -292,25 +293,68 @@ public class QuestionService {
 
     // ========== Helper Methods ==========
 
-    private String getDisplayName(User user, Section section, Boolean isAnonymous) {
-        if (isAnonymous) {
-            Optional<UserNickname> nicknameOpt = userNicknameRepository.findByUserAndSection(user, section);
-            if (nicknameOpt.isPresent()) {
-                return nicknameOpt.get().getNickname();
-            } else {
-                // 별명이 없으면 기본 별명 생성
-                String defaultNickname = "익명" + user.getId();
-                UserNickname nickname = UserNickname.builder()
-                        .user(user)
-                        .section(section)
-                        .nickname(defaultNickname)
-                        .build();
-                userNicknameRepository.save(nickname);
-                return defaultNickname;
-            }
-        } else {
+    private QuestionListDto toQuestionListDto(Question question, User viewer, Section section) {
+        QuestionListDto dto = QuestionListDto.fromEntity(question);
+        dto.setIsAuthor(question.getAuthor().getId().equals(viewer.getId()));
+        if (isInstructor(viewer, section)) {
+            dto.setAuthorRealNameForStaff(question.getAuthor().getName());
+            dto.setAuthorId(question.getAuthor().getId());
+        } else if (!Boolean.TRUE.equals(question.getIsAnonymous())) {
+            dto.setAuthorId(question.getAuthor().getId());
+        }
+        return dto;
+    }
+
+    private Boolean resolveAnonymousUseNickname(QuestionCreateDto dto) {
+        if (!Boolean.TRUE.equals(dto.getIsAnonymous())) {
+            return null;
+        }
+        if (dto.getAnonymousUseNickname() == null) {
+            return true;
+        }
+        return dto.getAnonymousUseNickname();
+    }
+
+    private String getDisplayName(User user, Section section, Boolean isAnonymous, Boolean anonymousUseNickname) {
+        if (!Boolean.TRUE.equals(isAnonymous)) {
             return user.getName();
         }
+        if (Boolean.FALSE.equals(anonymousUseNickname)) {
+            return "익명";
+        }
+        return pickUniqueRandomDisplayName(section);
+    }
+
+    /**
+     * 섹션 내 UserNickname 및 익명 질문 표시명과 겹치지 않게 형용사+명사 조합 생성
+     */
+    private String pickUniqueRandomDisplayName(Section section) {
+        for (int i = 0; i < 80; i++) {
+            String candidate = CommunityDisplayNameGenerator.randomDisplayName();
+            if (!isDisplayNameTakenInSection(section, candidate)) {
+                return candidate;
+            }
+        }
+        for (int j = 0; j < 40; j++) {
+            String base = CommunityDisplayNameGenerator.randomDisplayName();
+            String suffix = CommunityDisplayNameGenerator.numericSuffix();
+            String candidate = trimTo50(base + suffix);
+            if (!isDisplayNameTakenInSection(section, candidate)) {
+                return candidate;
+            }
+        }
+        return trimTo50("익명" + System.currentTimeMillis());
+    }
+
+    private static String trimTo50(String s) {
+        return s.length() > 50 ? s.substring(0, 50) : s;
+    }
+
+    private boolean isDisplayNameTakenInSection(Section section, String name) {
+        if (userNicknameRepository.existsBySectionAndNickname(section, name)) {
+            return true;
+        }
+        return questionRepository.existsBySectionAndIsAnonymousTrueAndAuthorDisplayName(section, name);
     }
 
     private boolean isInstructor(User user, Section section) {
@@ -324,10 +368,24 @@ public class QuestionService {
     }
 
     private QuestionResponseDto convertToResponseDto(Question question, Long currentUserId) {
+        User viewer = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new CustomException("사용자를 찾을 수 없습니다"));
+        boolean manager = isInstructor(viewer, question.getSection());
+
         QuestionResponseDto dto = QuestionResponseDto.fromEntity(question);
         dto.setIsLikedByCurrentUser(
                 questionLikeRepository.existsByQuestionIdAndUserId(question.getId(), currentUserId));
         dto.setIsAuthor(question.getAuthor().getId().equals(currentUserId));
+
+        if (Boolean.TRUE.equals(question.getIsAnonymous()) && !manager) {
+            dto.setAuthorId(null);
+        } else {
+            dto.setAuthorId(question.getAuthor().getId());
+        }
+        if (manager) {
+            dto.setAuthorRealNameForStaff(question.getAuthor().getName());
+        }
+
         return dto;
     }
 }

--- a/src/main/java/com/project/handongjudge/community/util/CommunityDisplayNameGenerator.java
+++ b/src/main/java/com/project/handongjudge/community/util/CommunityDisplayNameGenerator.java
@@ -1,0 +1,45 @@
+package com.project.handongjudge.community.util;
+
+import java.security.SecureRandom;
+
+/**
+ * 커뮤니티 익명 질문 표시용: 형용사 + 명사 조합 (클래스크래프트 스타일)
+ */
+public final class CommunityDisplayNameGenerator {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private static final String[] ADJECTIVES = {
+            "멋진", "용감한", "똑똑한", "귀여운", "신나는", "빠른", "조용한", "친절한", "활발한", "착한",
+            "열정적인", "차분한", "밝은", "당당한", "영리한", "맑은", "든든한", "상냥한", "유쾌한", "씩씩한",
+            "총명한", "다정한", "명랑한", "기운찬", "포근한", "산뜻한", "반짝이는", "늠름한", "싱그러운",
+            "재빠른", "느긋한", "기특한", "사랑스러운", "호탕한", "정직한", "온화한", "쾌활한", "소심한", "대담한"
+    };
+
+    private static final String[] NOUNS = {
+            "잠자리", "펭귄", "호랑이", "사자", "고양이", "강아지", "독수리", "참새", "다람쥐", "햄스터",
+            "거북이", "두더지", "너구리", "수달", "늑대", "여우", "곰", "판다", "코알라", "토끼",
+            "돌고래", "고래", "문어", "해파리", "가오리", "부엉이", "까치", "까마귀", "두루미", "공작",
+            "나무늘보", "카멜레온", "이구아나", "앵무새", "플라밍고", "기린", "얼룩말", "하마", "코뿔소", "수리부엉이"
+    };
+
+    private CommunityDisplayNameGenerator() {
+    }
+
+    /**
+     * @return "형용사 명사" 형태, DB 컬럼 길이(50) 이내
+     */
+    public static String randomDisplayName() {
+        String adj = ADJECTIVES[RANDOM.nextInt(ADJECTIVES.length)];
+        String noun = NOUNS[RANDOM.nextInt(NOUNS.length)];
+        String combined = adj + " " + noun;
+        return combined.length() > 50 ? combined.substring(0, 50) : combined;
+    }
+
+    /**
+     * 충돌 시 붙일 짧은 접미사 (숫자만)
+     */
+    public static String numericSuffix() {
+        return String.valueOf(1000 + RANDOM.nextInt(9000));
+    }
+}

--- a/src/main/java/com/project/handongjudge/section/controller/SectionController.java
+++ b/src/main/java/com/project/handongjudge/section/controller/SectionController.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.web.bind.annotation.*;
 import com.project.handongjudge.section.dto.SectionCopyRequest;
 import java.time.LocalDateTime;
@@ -45,9 +46,17 @@ public class SectionController {
     }
 
     @GetMapping("/{sectionId}")
-    public ResponseEntity<SectionInfoDto> getSectionInfo(@PathVariable Long sectionId) {
+    public ResponseEntity<SectionInfoDto> getSectionInfo(
+            @PathVariable Long sectionId,
+            Authentication authentication) {
         try {
-            SectionInfoDto sectionInfo = sectionService.getSectionInfo(sectionId);
+            Long userId = null;
+            if (authentication != null
+                    && authentication.isAuthenticated()
+                    && !(authentication instanceof AnonymousAuthenticationToken)) {
+                userId = Long.parseLong(authentication.getName());
+            }
+            SectionInfoDto sectionInfo = sectionService.getSectionInfo(sectionId, userId);
             return ResponseEntity.ok(sectionInfo);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();

--- a/src/main/java/com/project/handongjudge/section/dto/SectionInfoDto.java
+++ b/src/main/java/com/project/handongjudge/section/dto/SectionInfoDto.java
@@ -15,6 +15,10 @@ public class SectionInfoDto {
     private Integer sectionNumber;
     private String courseTitle;
     private String instructorName;
+    /** 담당 교수 user id */
+    private Long instructorId;
+    /** 현재 로그인 사용자가 이 분반 교수/TA(매니저)인지 */
+    private Boolean isCurrentUserSectionStaff;
     private String enrollmentCode;  // 추가
     private Boolean active;  // 추가
 

--- a/src/main/java/com/project/handongjudge/section/service/SectionService.java
+++ b/src/main/java/com/project/handongjudge/section/service/SectionService.java
@@ -104,14 +104,23 @@ public class SectionService {
     // SectionService의 getSectionInfo 메서드 수정
 
     public SectionInfoDto getSectionInfo(Long sectionId) {
+        return getSectionInfo(sectionId, null);
+    }
+
+    public SectionInfoDto getSectionInfo(Long sectionId, Long currentUserId) {
         Section section = sectionRepository.findById(sectionId)
                 .orElseThrow(() -> new IllegalArgumentException("분반을 찾을 수 없습니다: " + sectionId));
+
+        boolean staff = currentUserId != null
+                && sectionRoleService.isManager(currentUserId, sectionId);
 
         return SectionInfoDto.builder()
                 .sectionId(section.getId())
                 .sectionNumber(section.getSectionNumber())
                 .courseTitle(section.getCourse().getTitle())
                 .instructorName(section.getInstructor().getName())
+                .instructorId(section.getInstructor().getId())
+                .isCurrentUserSectionStaff(staff)
                 .enrollmentCode(section.getEnrollmentCode())  // 추가
                 .active(section.getActive())  // 추가
                 .build();


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #193 

## 📝작업 내용
## 요약
커뮤니티 질의응답: 익명 표시명 무작위 생성, 교수/TA 신원 노출, 댓글 익명 번호, 채택 제거, 분반 정보 확장.

## 변경 사항

### 질문 (Question)
- 익명 + 「별칭 모드」 시 **형용사+명사** 무작위 표시명 (`CommunityDisplayNameGenerator`).
- 같은 **섹션**에서 `UserNickname.nickname` 및 **익명 질문**의 `author_display_name`과 겹치지 않게 재시도 후 저장.
- 익명 + 「익명만」 모드는 표시명 `"익명"` 유지.
- `anonymous_use_nickname` 컬럼 (DDL `ddl-auto: update` 반영).

### API 응답 / 권한
- 질문 상세: 익명이면 일반 사용자에게 `authorId` 미포함; **매니저(교수/TA)** 에게만 `authorRealNameForStaff`.
- 질문 목록: `isAuthor`, 매니저에게 `authorRealNameForStaff`, `authorId`(선택적).

### 댓글 (Comment)
- 익명 댓글은 DB에는 플레이스홀더, 목록 조회 시 질문 내 **작성 순**으로 `익명 1`, `익명 2` … 표시.
- 익명이면 **`isInstructorAnswer` 미표시**(저장/응답에서 익명 시 false 처리).
- 일반 사용자에게 익명 댓글 `authorId` 숨김; 매니저에게 `authorRealNameForStaff`.

### 채택 기능 제거
- `POST/DELETE .../comments/{id}/accept` 엔드포인트 및 서비스 로직 삭제.
- `CommentRepository.findAcceptedCommentsByQuestion` 제거.

### 분반 정보
- `SectionInfoDto`: `instructorId`, `isCurrentUserSectionStaff`.
- `GET /api/sections/{id}`: 로그인 시 `sectionRoleService.isManager` 반영 (익명 세션 제외).

### 기타
- `QuestionRepository.existsBySectionAndIsAnonymousTrueAndAuthorDisplayName` 추가.

## 마이그레이션 / 배포
- MariaDB: Hibernate `ddl-auto: update` 환경에서 신규 컬럼 자동 반영 전제.

## 관련 경로 (참고)
- `community/util/CommunityDisplayNameGenerator.java`
- `community/service/QuestionService.java`, `CommentService.java`
- `section/dto/SectionInfoDto.java`, `SectionService.java`, `SectionController.java`