### PR TITLE
feat(config): HikariCP 커넥션 풀 설정 추가

### DIFF
--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -3,6 +3,15 @@
 spring:
   jpa:
     show-sql: false
+  datasource:
+    hikari:
+      maximum-pool-size: 25
+      minimum-idle: 5
+      connection-timeout: 30000     # 커넥션 획득 최대 대기 시간 (ms)
+      idle-timeout: 600000          # 유휴 커넥션 유지 시간 (ms)
+      max-lifetime: 1800000         # 커넥션 최대 수명 (ms), MariaDB wait_timeout 이하
+      keepalive-time: 60000         # 유휴 커넥션 ping 주기 (ms)
+      pool-name: HikariPool-Deploy
   redis:
     host: ${REDIS_HOST}
     port: ${REDIS_PORT:6379}


### PR DESCRIPTION
- 서버 스펙(물리 코어 10, SSD) 기반으로 최적 pool size 산출 후 배포 환경에 적용
- maximum-pool-size: 25 (공식: 코어×2+스핀들 = 21, 여유분 포함)
- min-idle, connection-timeout, max-lifetime, keepalive-time 명시적 설정

#202  참고

